### PR TITLE
Translate plan-and-execute notebook to Korean

### DIFF
--- a/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb
+++ b/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb
@@ -10,27 +10,24 @@
    "id": "79b5811c-1074-495f-9722-8325b5e717d3",
    "metadata": {},
    "source": [
-    "# Plan-and-Execute\n",
-    "\n",
-    "This notebook shows how to create a \"plan-and-execute\" style agent. This is heavily inspired by the [Plan-and-Solve](https://arxiv.org/abs/2305.04091) paper as well as the [Baby-AGI](https://github.com/yoheinakajima/babyagi) project.\n",
-    "\n",
-    "The core idea is to first come up with a multi-step plan, and then go through that plan one item at a time.\n",
-    "After accomplishing a particular task, you can then revisit the plan and modify as appropriate.\n",
-    "\n",
-    "\n",
-    "The general computational graph looks like the following:\n",
-    "\n",
-    "![plan-and-execute diagram](attachment:86cf6404-3d9b-41cb-ab97-5e451f576620.png)\n",
-    "\n",
-    "\n",
-    "This compares to a typical [ReAct](https://arxiv.org/abs/2210.03629) style agent where you think one step at a time.\n",
-    "The advantages of this \"plan-and-execute\" style agent are:\n",
-    "\n",
-    "1. Explicit long term planning (which even really strong LLMs can struggle with)\n",
-    "2. Ability to use smaller/weaker models for the execution step, only using larger/better models for the planning step\n",
-    "\n",
-    "\n",
-    "The following walkthrough demonstrates how to do so in LangGraph. The resulting agent will leave a trace like the following example: ([link](https://smith.langchain.com/public/d46e24d3-dda6-44d5-9550-b618fca4e0d4/r))."
+    "# 계획-실행(Plan-and-Execute)",
+    "",
+    "이 노트북은 \"계획-실행\" 방식의 에이전트를 만드는 방법을 보여줍니다. 이 아이디어는 [Plan-and-Solve](https://arxiv.org/abs/2305.04091) 논문과 [Baby-AGI](https://github.com/yoheinakajima/babyagi) 프로젝트에서 많은 영감을 받았습니다.",
+    "",
+    "핵심 아이디어는 먼저 여러 단계로 된 계획을 세우고, 그 계획을 한 항목씩 순차적으로 수행하는 것입니다.",
+    "특정 작업을 완료한 후에는 계획을 다시 검토하고 필요에 따라 수정할 수 있습니다.",
+    "",
+    "일반적인 계산 그래프는 다음과 같습니다:",
+    "",
+    "![plan-and-execute diagram](attachment:86cf6404-3d9b-41cb-ab97-5e451f576620.png)",
+    "",
+    "이는 한 번에 한 단계씩 생각하는 전형적인 [ReAct](https://arxiv.org/abs/2210.03629) 스타일의 에이전트와 비교됩니다.",
+    "\"계획-실행\" 스타일 에이전트의 장점은 다음과 같습니다:",
+    "",
+    "1. 명시적인 장기 계획 수립(이는 아주 강력한 LLM도 어려워할 수 있습니다)",
+    "2. 실행 단계에는 더 작거나 약한 모델을 사용하고, 계획 단계에만 더 크고 강력한 모델을 사용할 수 있는 능력",
+    "",
+    "아래 walkthrough에서는 LangGraph에서 이를 수행하는 방법을 보여줍니다. 생성된 에이전트는 다음 예시와 같은 트레이스를 남깁니다: ([링크](https://smith.langchain.com/public/d46e24d3-dda6-44d5-9550-b618fca4e0d4/r))."
    ]
   },
   {
@@ -38,9 +35,9 @@
    "id": "a44a72d6-7e0c-4478-9d20-4c09000420a8",
    "metadata": {},
    "source": [
-    "## Setup\n",
-    "\n",
-    "First, we need to install the packages required."
+    "## 설정",
+    "",
+    "먼저 필요한 패키지들을 설치합니다."
    ]
   },
   {
@@ -49,17 +46,14 @@
    "id": "b451b58a-89bd-424f-8c06-0d9fe325e01b",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%%capture --no-stderr\n",
-    "%pip install --quiet -U langgraph langchain-community langchain-openai tavily-python"
-   ]
+   "source": "%%capture --no-stderr\n%pip install --quiet -U langgraph langchain-community langchain-openai tavily-python"
   },
   {
    "cell_type": "markdown",
    "id": "35f267b0-98db-4a59-8b2c-a23f795576ff",
    "metadata": {},
    "source": [
-    "Next, we need to set API keys for OpenAI (the LLM we will use) and Tavily (the search tool we will use)"
+    "다음으로, 사용할 LLM인 OpenAI와 검색 도구인 Tavily의 API 키를 설정해야 합니다."
    ]
   },
   {
@@ -68,30 +62,18 @@
    "id": "ce438281-08d5-4804-afe7-e4089f7b016b",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import getpass\n",
-    "import os\n",
-    "\n",
-    "\n",
-    "def _set_env(var: str):\n",
-    "    if not os.environ.get(var):\n",
-    "        os.environ[var] = getpass.getpass(f\"{var}: \")\n",
-    "\n",
-    "\n",
-    "_set_env(\"OPENAI_API_KEY\")\n",
-    "_set_env(\"TAVILY_API_KEY\")"
-   ]
+   "source": "import getpass\nimport os\n\n\ndef _set_env(var: str):\n    if not os.environ.get(var):\n        os.environ[var] = getpass.getpass(f\"{var}: \")\n\n\n_set_env(\"OPENAI_API_KEY\")\n_set_env(\"TAVILY_API_KEY\")"
   },
   {
    "cell_type": "markdown",
    "id": "be2d7981-3737-4134-8bef-d00d18d4e91d",
    "metadata": {},
    "source": [
-    "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
-    "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
-    "    </p>\n",
+    "<div class=\"admonition tip\">",
+    "    <p class=\"admonition-title\">LangGraph 개발을 위해 <a href=\"https://smith.langchain.com\">LangSmith</a> 설정하기</p>",
+    "    <p style=\"padding-top: 5px;\">",
+    "        LangSmith에 가입하면 LangGraph 프로젝트의 문제를 빠르게 파악하고 성능을 향상시킬 수 있습니다. LangSmith는 LangGraph로 만든 LLM 앱을 디버그·테스트·모니터링할 수 있는 트레이스 데이터를 제공합니다 — 시작하는 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 자세히 알아보세요.",
+    "    </p>",
     "</div>"
    ]
   },
@@ -100,9 +82,9 @@
    "id": "6c5fb09a-0311-44c2-b243-d0e80de78902",
    "metadata": {},
    "source": [
-    "## Define Tools\n",
-    "\n",
-    "We will first define the tools we want to use. For this simple example, we will use a built-in search tool via Tavily. However, it is really easy to create your own tools - see documentation [here](https://python.langchain.com/docs/how_to/custom_tools) on how to do that."
+    "## 도구 정의",
+    "",
+    "먼저 사용할 도구들을 정의하겠습니다. 이 간단한 예제에서는 Tavily를 통한 내장 검색 도구를 사용합니다. 그러나 [문서](https://python.langchain.com/docs/how_to/custom_tools)를 참고하면 원하는 도구를 아주 쉽게 만들 수 있습니다."
    ]
   },
   {
@@ -111,21 +93,17 @@
    "id": "25b9ec62-0675-4715-811c-9b32c635b22f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from langchain_community.tools.tavily_search import TavilySearchResults\n",
-    "\n",
-    "tools = [TavilySearchResults(max_results=3)]"
-   ]
+   "source": "from langchain_community.tools.tavily_search import TavilySearchResults\n\ntools = [TavilySearchResults(max_results=3)]"
   },
   {
    "cell_type": "markdown",
    "id": "3dcda478-fa80-4e3e-bb35-0f622fe73a31",
    "metadata": {},
    "source": [
-    "## Define our Execution Agent\n",
-    "\n",
-    "Now we will create the execution agent we want to use to execute tasks. \n",
-    "Note that for this example, we will be using the same execution agent for each task, but this doesn't HAVE to be the case."
+    "## 실행 에이전트 정의",
+    "",
+    "이제 작업을 수행할 실행 에이전트를 만들겠습니다. ",
+    "이 예제에서는 모든 작업에 동일한 실행 에이전트를 사용하지만, 반드시 이렇게 해야 하는 것은 아닙니다."
    ]
   },
   {
@@ -134,16 +112,7 @@
    "id": "72d233ca-1dbf-4b43-b680-b3bf39e3691f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from langchain_openai import ChatOpenAI\n",
-    "\n",
-    "from langgraph.prebuilt import create_react_agent\n",
-    "\n",
-    "# Choose the LLM that will drive the agent\n",
-    "llm = ChatOpenAI(model=\"gpt-4-turbo-preview\")\n",
-    "prompt = \"You are a helpful assistant.\"\n",
-    "agent_executor = create_react_agent(llm, tools, prompt=prompt)"
-   ]
+   "source": "from langchain_openai import ChatOpenAI\n\nfrom langgraph.prebuilt import create_react_agent\n\n# Choose the LLM that will drive the agent\nllm = ChatOpenAI(model=\"gpt-4-turbo-preview\")\nprompt = \"You are a helpful assistant.\"\nagent_executor = create_react_agent(llm, tools, prompt=prompt)"
   },
   {
    "cell_type": "code",
@@ -153,36 +122,29 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "{'messages': [HumanMessage(content='who is the winnner of the us open', additional_kwargs={}, response_metadata={}, id='388a14b3-f556-4f91-ad36-def0a075638e'),\n",
-       "  AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_5nbeRa0fgh4ZslRkjk75Kzxs', 'function': {'arguments': '{\"query\":\"US Open 2023 winner\"}', 'name': 'tavily_search_results_json'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 23, 'prompt_tokens': 97, 'total_tokens': 120, 'completion_tokens_details': {'reasoning_tokens': 0}}, 'model_name': 'gpt-4-0125-preview', 'system_fingerprint': None, 'finish_reason': 'tool_calls', 'logprobs': None}, id='run-3bb25f7a-49e5-43b7-ad53-718bd0107db1-0', tool_calls=[{'name': 'tavily_search_results_json', 'args': {'query': 'US Open 2023 winner'}, 'id': 'call_5nbeRa0fgh4ZslRkjk75Kzxs', 'type': 'tool_call'}], usage_metadata={'input_tokens': 97, 'output_tokens': 23, 'total_tokens': 120}),\n",
-       "  ToolMessage(content='[{\"url\": \"https://www.youtube.com/watch?v=rZ0XQWWFIAo\", \"content\": \"The moment Coco Gauff beat Aryna Sabalenka in the final of the 2023 US Open.Don\\'t miss a moment of the US Open! Subscribe now: https://bit.ly/2Pdr81iThe 2023...\"}, {\"url\": \"https://www.cbssports.com/tennis/news/us-open-2023-scores-novak-djokovic-makes-history-with-24th-grand-slam-title-while-coco-gauff-earns-her-first/\", \"content\": \"Here is all you need to know about the 2023 US Open:\\\\nMen\\'s final\\\\nWomen\\'s final\\\\nMen\\'s singles seeds\\\\nWomen\\'s singles seeds\\\\nOur Latest Tennis Stories\\\\nUS Open 2023: Schedule, scores, how to watch, seeds\\\\nRafael Nadal to return next month at Brisbane\\\\nNovak Djokovic breaks Federer\\'s ATP Finals record\\\\nTennis bettor wins $486,000 off $28 on 10-match parlay\\\\nTennis player DQ\\'d on match point for hitting umpire\\\\nRafael Nadal says Novak Djokovic is tennis\\' GOAT\\\\nHalep suspended four years for anti-doping violations\\\\nDjokovic pays tribute to Kobe after winning US Open\\\\nDjokovic vs. Medvedev odds, US Open final picks, bets\\\\nAryna Sabalenka-Coco Gauff odds, US Open final picks\\\\n© 2004-2023 CBS Interactive. Novak Djokovic makes history with 24th Grand Slam title, while Coco Gauff earns her first\\\\nThe 2023 US Open is officially in the books\\\\nThe 2023 US open came to a close as Coco Gauff earned her first major title and Novak Djokovic made history with his 24th Grand Slam trophy. Gauff is the first woman to win the Cincinnati Masters 1000 and US Open in the same year since Williams in 2014.\\\\n Gauff landed in New York as the No. 6 player in the world but will be climbing to a career-best No. 3 when the next rankings get released.\\\\n He arrived to this competition as the world No. 2 but will improve to No. 1 in the next rankings, extending his record total of 389 weeks at the top.\\\\n\"}, {\"url\": \"https://www.usopen.org/en_US/news/articles/2023-09-10/novak_djokovic_wins_24th_grand_slam_singles_title_at_2023_us_open.html\", \"content\": \"Novak Djokovic defeated Daniil Medvedev in three sets to claim his 24th Grand Slam singles title and match Margaret Court\\'s all-time record. The Serb saved a set point in the second set and attacked the net to win his fourth US Open crown.\"}]', name='tavily_search_results_json', id='3ea00623-86b3-4d6f-9978-3503a7eecf0f', tool_call_id='call_5nbeRa0fgh4ZslRkjk75Kzxs', artifact={'query': 'US Open 2023 winner', 'follow_up_questions': None, 'answer': None, 'images': [], 'results': [{'title': \"Championship Point | Coco Gauff Wins Women's Singles Title | 2023 US Open\", 'url': 'https://www.youtube.com/watch?v=rZ0XQWWFIAo', 'content': \"The moment Coco Gauff beat Aryna Sabalenka in the final of the 2023 US Open.Don't miss a moment of the US Open! Subscribe now: https://bit.ly/2Pdr81iThe 2023...\", 'score': 0.9975177, 'raw_content': None}, {'title': 'US Open 2023 scores: Novak Djokovic makes history with 24th Grand Slam ...', 'url': 'https://www.cbssports.com/tennis/news/us-open-2023-scores-novak-djokovic-makes-history-with-24th-grand-slam-title-while-coco-gauff-earns-her-first/', 'content': \"Here is all you need to know about the 2023 US Open:\\nMen's final\\nWomen's final\\nMen's singles seeds\\nWomen's singles seeds\\nOur Latest Tennis Stories\\nUS Open 2023: Schedule, scores, how to watch, seeds\\nRafael Nadal to return next month at Brisbane\\nNovak Djokovic breaks Federer's ATP Finals record\\nTennis bettor wins $486,000 off $28 on 10-match parlay\\nTennis player DQ'd on match point for hitting umpire\\nRafael Nadal says Novak Djokovic is tennis' GOAT\\nHalep suspended four years for anti-doping violations\\nDjokovic pays tribute to Kobe after winning US Open\\nDjokovic vs. Medvedev odds, US Open final picks, bets\\nAryna Sabalenka-Coco Gauff odds, US Open final picks\\n© 2004-2023 CBS Interactive. Novak Djokovic makes history with 24th Grand Slam title, while Coco Gauff earns her first\\nThe 2023 US Open is officially in the books\\nThe 2023 US open came to a close as Coco Gauff earned her first major title and Novak Djokovic made history with his 24th Grand Slam trophy. Gauff is the first woman to win the Cincinnati Masters 1000 and US Open in the same year since Williams in 2014.\\n Gauff landed in New York as the No. 6 player in the world but will be climbing to a career-best No. 3 when the next rankings get released.\\n He arrived to this competition as the world No. 2 but will improve to No. 1 in the next rankings, extending his record total of 389 weeks at the top.\\n\", 'score': 0.9937101, 'raw_content': None}, {'title': 'Novak Djokovic wins 24th Grand Slam singles title at 2023 US Open', 'url': 'https://www.usopen.org/en_US/news/articles/2023-09-10/novak_djokovic_wins_24th_grand_slam_singles_title_at_2023_us_open.html', 'content': \"Novak Djokovic defeated Daniil Medvedev in three sets to claim his 24th Grand Slam singles title and match Margaret Court's all-time record. The Serb saved a set point in the second set and attacked the net to win his fourth US Open crown.\", 'score': 0.8146434, 'raw_content': None}], 'response_time': 2.24}),\n",
-       "  AIMessage(content=\"The winners of the 2023 US Open are Coco Gauff and Novak Djokovic. Coco Gauff won her first major title at the US Open, making history, while Novak Djokovic secured his 24th Grand Slam title, matching Margaret Court's all-time record and winning his fourth US Open crown. Coco Gauff defeated Aryna Sabalenka in the final, and Novak Djokovic defeated Daniil Medvedev.\", additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 93, 'prompt_tokens': 751, 'total_tokens': 844, 'completion_tokens_details': {'reasoning_tokens': 0}}, 'model_name': 'gpt-4-0125-preview', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-eedb1782-6120-441d-ab5d-ccf6bef75b02-0', usage_metadata={'input_tokens': 751, 'output_tokens': 93, 'total_tokens': 844})]}"
-      ]
+      "text/plain": "{'messages': [HumanMessage(content='who is the winnner of the us open', additional_kwargs={}, response_metadata={}, id='388a14b3-f556-4f91-ad36-def0a075638e'),\n  AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_5nbeRa0fgh4ZslRkjk75Kzxs', 'function': {'arguments': '{\"query\":\"US Open 2023 winner\"}', 'name': 'tavily_search_results_json'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 23, 'prompt_tokens': 97, 'total_tokens': 120, 'completion_tokens_details': {'reasoning_tokens': 0}}, 'model_name': 'gpt-4-0125-preview', 'system_fingerprint': None, 'finish_reason': 'tool_calls', 'logprobs': None}, id='run-3bb25f7a-49e5-43b7-ad53-718bd0107db1-0', tool_calls=[{'name': 'tavily_search_results_json', 'args': {'query': 'US Open 2023 winner'}, 'id': 'call_5nbeRa0fgh4ZslRkjk75Kzxs', 'type': 'tool_call'}], usage_metadata={'input_tokens': 97, 'output_tokens': 23, 'total_tokens': 120}),\n  ToolMessage(content='[{\"url\": \"https://www.youtube.com/watch?v=rZ0XQWWFIAo\", \"content\": \"The moment Coco Gauff beat Aryna Sabalenka in the final of the 2023 US Open.Don\\'t miss a moment of the US Open! Subscribe now: https://bit.ly/2Pdr81iThe 2023...\"}, {\"url\": \"https://www.cbssports.com/tennis/news/us-open-2023-scores-novak-djokovic-makes-history-with-24th-grand-slam-title-while-coco-gauff-earns-her-first/\", \"content\": \"Here is all you need to know about the 2023 US Open:\\\\nMen\\'s final\\\\nWomen\\'s final\\\\nMen\\'s singles seeds\\\\nWomen\\'s singles seeds\\\\nOur Latest Tennis Stories\\\\nUS Open 2023: Schedule, scores, how to watch, seeds\\\\nRafael Nadal to return next month at Brisbane\\\\nNovak Djokovic breaks Federer\\'s ATP Finals record\\\\nTennis bettor wins $486,000 off $28 on 10-match parlay\\\\nTennis player DQ\\'d on match point for hitting umpire\\\\nRafael Nadal says Novak Djokovic is tennis\\' GOAT\\\\nHalep suspended four years for anti-doping violations\\\\nDjokovic pays tribute to Kobe after winning US Open\\\\nDjokovic vs. Medvedev odds, US Open final picks, bets\\\\nAryna Sabalenka-Coco Gauff odds, US Open final picks\\\\n© 2004-2023 CBS Interactive. Novak Djokovic makes history with 24th Grand Slam title, while Coco Gauff earns her first\\\\nThe 2023 US Open is officially in the books\\\\nThe 2023 US open came to a close as Coco Gauff earned her first major title and Novak Djokovic made history with his 24th Grand Slam trophy. Gauff is the first woman to win the Cincinnati Masters 1000 and US Open in the same year since Williams in 2014.\\\\n Gauff landed in New York as the No. 6 player in the world but will be climbing to a career-best No. 3 when the next rankings get released.\\\\n He arrived to this competition as the world No. 2 but will improve to No. 1 in the next rankings, extending his record total of 389 weeks at the top.\\\\n\"}, {\"url\": \"https://www.usopen.org/en_US/news/articles/2023-09-10/novak_djokovic_wins_24th_grand_slam_singles_title_at_2023_us_open.html\", \"content\": \"Novak Djokovic defeated Daniil Medvedev in three sets to claim his 24th Grand Slam singles title and match Margaret Court\\'s all-time record. The Serb saved a set point in the second set and attacked the net to win his fourth US Open crown.\"}]', name='tavily_search_results_json', id='3ea00623-86b3-4d6f-9978-3503a7eecf0f', tool_call_id='call_5nbeRa0fgh4ZslRkjk75Kzxs', artifact={'query': 'US Open 2023 winner', 'follow_up_questions': None, 'answer': None, 'images': [], 'results': [{'title': \"Championship Point | Coco Gauff Wins Women's Singles Title | 2023 US Open\", 'url': 'https://www.youtube.com/watch?v=rZ0XQWWFIAo', 'content': \"The moment Coco Gauff beat Aryna Sabalenka in the final of the 2023 US Open.Don't miss a moment of the US Open! Subscribe now: https://bit.ly/2Pdr81iThe 2023...\", 'score': 0.9975177, 'raw_content': None}, {'title': 'US Open 2023 scores: Novak Djokovic makes history with 24th Grand Slam ...', 'url': 'https://www.cbssports.com/tennis/news/us-open-2023-scores-novak-djokovic-makes-history-with-24th-grand-slam-title-while-coco-gauff-earns-her-first/', 'content': \"Here is all you need to know about the 2023 US Open:\\nMen's final\\nWomen's final\\nMen's singles seeds\\nWomen's singles seeds\\nOur Latest Tennis Stories\\nUS Open 2023: Schedule, scores, how to watch, seeds\\nRafael Nadal to return next month at Brisbane\\nNovak Djokovic breaks Federer's ATP Finals record\\nTennis bettor wins $486,000 off $28 on 10-match parlay\\nTennis player DQ'd on match point for hitting umpire\\nRafael Nadal says Novak Djokovic is tennis' GOAT\\nHalep suspended four years for anti-doping violations\\nDjokovic pays tribute to Kobe after winning US Open\\nDjokovic vs. Medvedev odds, US Open final picks, bets\\nAryna Sabalenka-Coco Gauff odds, US Open final picks\\n© 2004-2023 CBS Interactive. Novak Djokovic makes history with 24th Grand Slam title, while Coco Gauff earns her first\\nThe 2023 US Open is officially in the books\\nThe 2023 US open came to a close as Coco Gauff earned her first major title and Novak Djokovic made history with his 24th Grand Slam trophy. Gauff is the first woman to win the Cincinnati Masters 1000 and US Open in the same year since Williams in 2014.\\n Gauff landed in New York as the No. 6 player in the world but will be climbing to a career-best No. 3 when the next rankings get released.\\n He arrived to this competition as the world No. 2 but will improve to No. 1 in the next rankings, extending his record total of 389 weeks at the top.\\n\", 'score': 0.9937101, 'raw_content': None}, {'title': 'Novak Djokovic wins 24th Grand Slam singles title at 2023 US Open', 'url': 'https://www.usopen.org/en_US/news/articles/2023-09-10/novak_djokovic_wins_24th_grand_slam_singles_title_at_2023_us_open.html', 'content': \"Novak Djokovic defeated Daniil Medvedev in three sets to claim his 24th Grand Slam singles title and match Margaret Court's all-time record. The Serb saved a set point in the second set and attacked the net to win his fourth US Open crown.\", 'score': 0.8146434, 'raw_content': None}], 'response_time': 2.24}),\n  AIMessage(content=\"The winners of the 2023 US Open are Coco Gauff and Novak Djokovic. Coco Gauff won her first major title at the US Open, making history, while Novak Djokovic secured his 24th Grand Slam title, matching Margaret Court's all-time record and winning his fourth US Open crown. Coco Gauff defeated Aryna Sabalenka in the final, and Novak Djokovic defeated Daniil Medvedev.\", additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 93, 'prompt_tokens': 751, 'total_tokens': 844, 'completion_tokens_details': {'reasoning_tokens': 0}}, 'model_name': 'gpt-4-0125-preview', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-eedb1782-6120-441d-ab5d-ccf6bef75b02-0', usage_metadata={'input_tokens': 751, 'output_tokens': 93, 'total_tokens': 844})]}"
      },
      "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "agent_executor.invoke({\"messages\": [(\"user\", \"who is the winnner of the us open\")]})"
-   ]
+   "source": "agent_executor.invoke({\"messages\": [(\"user\", \"who is the winnner of the us open\")]})"
   },
   {
    "cell_type": "markdown",
    "id": "5cf66804-44b2-4904-b1a7-17ad70b551f5",
    "metadata": {},
    "source": [
-    "## Define the State\n",
-    "\n",
-    "Let's now start by defining the state the track for this agent.\n",
-    "\n",
-    "First, we will need to track the current plan. Let's represent that as a list of strings.\n",
-    "\n",
-    "Next, we should track previously executed steps. Let's represent that as a list of tuples (these tuples will contain the step and then the result)\n",
-    "\n",
-    "Finally, we need to have some state to represent the final response as well as the original input."
+    "## 상태 정의",
+    "",
+    "이제 이 에이전트가 추적할 상태를 정의해 보겠습니다.",
+    "",
+    "먼저 현재 계획을 추적해야 합니다. 이를 문자열 리스트로 표현합니다.",
+    "",
+    "다음으로 이전에 실행한 단계들을 추적해야 합니다. 이를 (단계와 결과를 포함하는) 튜플 리스트로 표현합니다.",
+    "",
+    "마지막으로 최종 응답과 원래 입력을 나타내는 상태가 필요합니다."
    ]
   },
   {
@@ -191,27 +153,16 @@
    "id": "8eeeaeea-8f10-4fbe-8e24-4e1a2381a009",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import operator\n",
-    "from typing import Annotated, List, Tuple\n",
-    "from typing_extensions import TypedDict\n",
-    "\n",
-    "\n",
-    "class PlanExecute(TypedDict):\n",
-    "    input: str\n",
-    "    plan: List[str]\n",
-    "    past_steps: Annotated[List[Tuple], operator.add]\n",
-    "    response: str"
-   ]
+   "source": "import operator\nfrom typing import Annotated, List, Tuple\nfrom typing_extensions import TypedDict\n\n\nclass PlanExecute(TypedDict):\n    input: str\n    plan: List[str]\n    past_steps: Annotated[List[Tuple], operator.add]\n    response: str"
   },
   {
    "cell_type": "markdown",
    "id": "1dbd770a-9941-40a9-977e-4d55359eee21",
    "metadata": {},
    "source": [
-    "## Planning Step\n",
-    "\n",
-    "Let's now think about creating the planning step. This will use function calling to create a plan."
+    "## 계획 단계",
+    "",
+    "이제 계획 단계를 만들어 보겠습니다. 여기서는 함수 호출을 사용해 계획을 생성합니다."
    ]
   },
   {
@@ -219,11 +170,11 @@
    "id": "e12494fa-c6a2-4cfa-ae58-f72961437843",
    "metadata": {},
    "source": [
-    "<div class=\"admonition note\">\n",
-    "    <p class=\"admonition-title\">Using Pydantic with LangChain</p>\n",
-    "    <p>\n",
-    "        This notebook uses Pydantic v2 <code>BaseModel</code>, which requires <code>langchain-core >= 0.3</code>. Using <code>langchain-core < 0.3</code> will result in errors due to mixing of Pydantic v1 and v2 <code>BaseModels</code>.\n",
-    "    </p>\n",
+    "<div class=\"admonition note\">",
+    "    <p class=\"admonition-title\">LangChain에서 Pydantic 사용하기</p>",
+    "    <p>",
+    "        이 노트북은 Pydantic v2 <code>BaseModel</code>을 사용하며, 이를 위해서는 <code>langchain-core >= 0.3</code>이 필요합니다. <code>langchain-core < 0.3</code>을 사용하면 Pydantic v1과 v2 <code>BaseModel</code>이 혼합되어 오류가 발생합니다.",
+    "    </p>",
     "</div>"
    ]
   },
@@ -233,17 +184,7 @@
    "id": "4a88626d-6dfd-4488-87f0-a9a0dd6da44c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from pydantic import BaseModel, Field\n",
-    "\n",
-    "\n",
-    "class Plan(BaseModel):\n",
-    "    \"\"\"Plan to follow in future\"\"\"\n",
-    "\n",
-    "    steps: List[str] = Field(\n",
-    "        description=\"different steps to follow, should be in sorted order\"\n",
-    "    )"
-   ]
+   "source": "from pydantic import BaseModel, Field\n\n\nclass Plan(BaseModel):\n    \"\"\"Plan to follow in future\"\"\"\n\n    steps: List[str] = Field(\n        description=\"different steps to follow, should be in sorted order\"\n    )"
   },
   {
    "cell_type": "code",
@@ -251,24 +192,7 @@
    "id": "ec7b1867-1ea3-4df3-9a98-992a1c32ec49",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from langchain_core.prompts import ChatPromptTemplate\n",
-    "\n",
-    "planner_prompt = ChatPromptTemplate.from_messages(\n",
-    "    [\n",
-    "        (\n",
-    "            \"system\",\n",
-    "            \"\"\"For the given objective, come up with a simple step by step plan. \\\n",
-    "This plan should involve individual tasks, that if executed correctly will yield the correct answer. Do not add any superfluous steps. \\\n",
-    "The result of the final step should be the final answer. Make sure that each step has all the information needed - do not skip steps.\"\"\",\n",
-    "        ),\n",
-    "        (\"placeholder\", \"{messages}\"),\n",
-    "    ]\n",
-    ")\n",
-    "planner = planner_prompt | ChatOpenAI(\n",
-    "    model=\"gpt-4o\", temperature=0\n",
-    ").with_structured_output(Plan)"
-   ]
+   "source": "from langchain_core.prompts import ChatPromptTemplate\n\nplanner_prompt = ChatPromptTemplate.from_messages(\n    [\n        (\n            \"system\",\n            \"\"\"For the given objective, come up with a simple step by step plan. \\\nThis plan should involve individual tasks, that if executed correctly will yield the correct answer. Do not add any superfluous steps. \\\nThe result of the final step should be the final answer. Make sure that each step has all the information needed - do not skip steps.\"\"\",\n        ),\n        (\"placeholder\", \"{messages}\"),\n    ]\n)\nplanner = planner_prompt | ChatOpenAI(\n    model=\"gpt-4o\", temperature=0\n).with_structured_output(Plan)"
   },
   {
    "cell_type": "code",
@@ -278,33 +202,23 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "Plan(steps=['Identify the current winner of the Australia Open.', 'Find the hometown of the identified winner.'])"
-      ]
+      "text/plain": "Plan(steps=['Identify the current winner of the Australia Open.', 'Find the hometown of the identified winner.'])"
      },
      "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "planner.invoke(\n",
-    "    {\n",
-    "        \"messages\": [\n",
-    "            (\"user\", \"what is the hometown of the current Australia open winner?\")\n",
-    "        ]\n",
-    "    }\n",
-    ")"
-   ]
+   "source": "planner.invoke(\n    {\n        \"messages\": [\n            (\"user\", \"what is the hometown of the current Australia open winner?\")\n        ]\n    }\n)"
   },
   {
    "cell_type": "markdown",
    "id": "6e09ad9d-6f90-4bdc-bb43-b1ce94517c29",
    "metadata": {},
    "source": [
-    "## Re-Plan Step\n",
-    "\n",
-    "Now, let's create a step that re-does the plan based on the result of the previous step."
+    "## 재계획 단계",
+    "",
+    "이제 이전 단계의 결과를 기반으로 계획을 다시 세우는 단계를 만들어 보겠습니다."
    ]
   },
   {
@@ -313,56 +227,16 @@
    "id": "ec2d12cc-016a-44d1-aa08-4c5ce1e8fe2a",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from typing import Union\n",
-    "\n",
-    "\n",
-    "class Response(BaseModel):\n",
-    "    \"\"\"Response to user.\"\"\"\n",
-    "\n",
-    "    response: str\n",
-    "\n",
-    "\n",
-    "class Act(BaseModel):\n",
-    "    \"\"\"Action to perform.\"\"\"\n",
-    "\n",
-    "    action: Union[Response, Plan] = Field(\n",
-    "        description=\"Action to perform. If you want to respond to user, use Response. \"\n",
-    "        \"If you need to further use tools to get the answer, use Plan.\"\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "replanner_prompt = ChatPromptTemplate.from_template(\n",
-    "    \"\"\"For the given objective, come up with a simple step by step plan. \\\n",
-    "This plan should involve individual tasks, that if executed correctly will yield the correct answer. Do not add any superfluous steps. \\\n",
-    "The result of the final step should be the final answer. Make sure that each step has all the information needed - do not skip steps.\n",
-    "\n",
-    "Your objective was this:\n",
-    "{input}\n",
-    "\n",
-    "Your original plan was this:\n",
-    "{plan}\n",
-    "\n",
-    "You have currently done the follow steps:\n",
-    "{past_steps}\n",
-    "\n",
-    "Update your plan accordingly. If no more steps are needed and you can return to the user, then respond with that. Otherwise, fill out the plan. Only add steps to the plan that still NEED to be done. Do not return previously done steps as part of the plan.\"\"\"\n",
-    ")\n",
-    "\n",
-    "\n",
-    "replanner = replanner_prompt | ChatOpenAI(\n",
-    "    model=\"gpt-4o\", temperature=0\n",
-    ").with_structured_output(Act)"
-   ]
+   "source": "from typing import Union\n\n\nclass Response(BaseModel):\n    \"\"\"Response to user.\"\"\"\n\n    response: str\n\n\nclass Act(BaseModel):\n    \"\"\"Action to perform.\"\"\"\n\n    action: Union[Response, Plan] = Field(\n        description=\"Action to perform. If you want to respond to user, use Response. \"\n        \"If you need to further use tools to get the answer, use Plan.\"\n    )\n\n\nreplanner_prompt = ChatPromptTemplate.from_template(\n    \"\"\"For the given objective, come up with a simple step by step plan. \\\nThis plan should involve individual tasks, that if executed correctly will yield the correct answer. Do not add any superfluous steps. \\\nThe result of the final step should be the final answer. Make sure that each step has all the information needed - do not skip steps.\n\nYour objective was this:\n{input}\n\nYour original plan was this:\n{plan}\n\nYou have currently done the follow steps:\n{past_steps}\n\nUpdate your plan accordingly. If no more steps are needed and you can return to the user, then respond with that. Otherwise, fill out the plan. Only add steps to the plan that still NEED to be done. Do not return previously done steps as part of the plan.\"\"\"\n)\n\n\nreplanner = replanner_prompt | ChatOpenAI(\n    model=\"gpt-4o\", temperature=0\n).with_structured_output(Act)"
   },
   {
    "cell_type": "markdown",
    "id": "859abd13-6ba0-45ad-b341-e652dd5f755b",
    "metadata": {},
    "source": [
-    "## Create the Graph\n",
-    "\n",
-    "We can now create the graph!"
+    "## 그래프 생성",
+    "",
+    "이제 그래프를 만들 수 있습니다!"
    ]
   },
   {
@@ -371,44 +245,7 @@
    "id": "6c8e0dad-bcea-4c9a-8922-0d820892e2d0",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from typing import Literal\n",
-    "from langgraph.graph import END\n",
-    "\n",
-    "\n",
-    "async def execute_step(state: PlanExecute):\n",
-    "    plan = state[\"plan\"]\n",
-    "    plan_str = \"\\n\".join(f\"{i + 1}. {step}\" for i, step in enumerate(plan))\n",
-    "    task = plan[0]\n",
-    "    task_formatted = f\"\"\"For the following plan:\n",
-    "{plan_str}\\n\\nYou are tasked with executing step {1}, {task}.\"\"\"\n",
-    "    agent_response = await agent_executor.ainvoke(\n",
-    "        {\"messages\": [(\"user\", task_formatted)]}\n",
-    "    )\n",
-    "    return {\n",
-    "        \"past_steps\": [(task, agent_response[\"messages\"][-1].content)],\n",
-    "    }\n",
-    "\n",
-    "\n",
-    "async def plan_step(state: PlanExecute):\n",
-    "    plan = await planner.ainvoke({\"messages\": [(\"user\", state[\"input\"])]})\n",
-    "    return {\"plan\": plan.steps}\n",
-    "\n",
-    "\n",
-    "async def replan_step(state: PlanExecute):\n",
-    "    output = await replanner.ainvoke(state)\n",
-    "    if isinstance(output.action, Response):\n",
-    "        return {\"response\": output.action.response}\n",
-    "    else:\n",
-    "        return {\"plan\": output.action.steps}\n",
-    "\n",
-    "\n",
-    "def should_end(state: PlanExecute):\n",
-    "    if \"response\" in state and state[\"response\"]:\n",
-    "        return END\n",
-    "    else:\n",
-    "        return \"agent\""
-   ]
+   "source": "from typing import Literal\nfrom langgraph.graph import END\n\n\nasync def execute_step(state: PlanExecute):\n    plan = state[\"plan\"]\n    plan_str = \"\\n\".join(f\"{i + 1}. {step}\" for i, step in enumerate(plan))\n    task = plan[0]\n    task_formatted = f\"\"\"For the following plan:\n{plan_str}\\n\\nYou are tasked with executing step {1}, {task}.\"\"\"\n    agent_response = await agent_executor.ainvoke(\n        {\"messages\": [(\"user\", task_formatted)]}\n    )\n    return {\n        \"past_steps\": [(task, agent_response[\"messages\"][-1].content)],\n    }\n\n\nasync def plan_step(state: PlanExecute):\n    plan = await planner.ainvoke({\"messages\": [(\"user\", state[\"input\"])]})\n    return {\"plan\": plan.steps}\n\n\nasync def replan_step(state: PlanExecute):\n    output = await replanner.ainvoke(state)\n    if isinstance(output.action, Response):\n        return {\"response\": output.action.response}\n    else:\n        return {\"plan\": output.action.steps}\n\n\ndef should_end(state: PlanExecute):\n    if \"response\" in state and state[\"response\"]:\n        return END\n    else:\n        return \"agent\""
   },
   {
    "cell_type": "code",
@@ -416,40 +253,7 @@
    "id": "e954cea0-5ccc-46c2-a27b-f5b7185b597d",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from langgraph.graph import StateGraph, START\n",
-    "\n",
-    "workflow = StateGraph(PlanExecute)\n",
-    "\n",
-    "# Add the plan node\n",
-    "workflow.add_node(\"planner\", plan_step)\n",
-    "\n",
-    "# Add the execution step\n",
-    "workflow.add_node(\"agent\", execute_step)\n",
-    "\n",
-    "# Add a replan node\n",
-    "workflow.add_node(\"replan\", replan_step)\n",
-    "\n",
-    "workflow.add_edge(START, \"planner\")\n",
-    "\n",
-    "# From plan we go to agent\n",
-    "workflow.add_edge(\"planner\", \"agent\")\n",
-    "\n",
-    "# From agent, we replan\n",
-    "workflow.add_edge(\"agent\", \"replan\")\n",
-    "\n",
-    "workflow.add_conditional_edges(\n",
-    "    \"replan\",\n",
-    "    # Next, we pass in the function that will determine which node is called next.\n",
-    "    should_end,\n",
-    "    [\"agent\", END],\n",
-    ")\n",
-    "\n",
-    "# Finally, we compile it!\n",
-    "# This compiles it into a LangChain Runnable,\n",
-    "# meaning you can use it as you would any other runnable\n",
-    "app = workflow.compile()"
-   ]
+   "source": "from langgraph.graph import StateGraph, START\n\nworkflow = StateGraph(PlanExecute)\n\n# Add the plan node\nworkflow.add_node(\"planner\", plan_step)\n\n# Add the execution step\nworkflow.add_node(\"agent\", execute_step)\n\n# Add a replan node\nworkflow.add_node(\"replan\", replan_step)\n\nworkflow.add_edge(START, \"planner\")\n\n# From plan we go to agent\nworkflow.add_edge(\"planner\", \"agent\")\n\n# From agent, we replan\nworkflow.add_edge(\"agent\", \"replan\")\n\nworkflow.add_conditional_edges(\n    \"replan\",\n    # Next, we pass in the function that will determine which node is called next.\n    should_end,\n    [\"agent\", END],\n)\n\n# Finally, we compile it!\n# This compiles it into a LangChain Runnable,\n# meaning you can use it as you would any other runnable\napp = workflow.compile()"
   },
   {
    "cell_type": "code",
@@ -460,19 +264,13 @@
     {
      "data": {
       "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCALAAW0DASIAAhEBAxEB/8QAHQABAAMBAQEBAQEAAAAAAAAAAAUGBwQIAwIBCf/EAF8QAAEDAwEDBAsLBwkEBgoDAAEAAgMEBQYRBxIhEzFB0RQWFyI2VVZ0kpSyCBUjMjVRU2FzsdNSVHF1lbPSJDM0N0KBk6K0JkeRoWJjg6PC1AklJ0NERmRygoR2lsT/xAAbAQEAAwEBAQEAAAAAAAAAAAAAAQIDBAUGB//EADwRAQABAQUDBwoFBQEBAQAAAAABAgMEERIxFFGRBSEyQVNxwRMVM1JhcpLC0dI0YoGhsSIjQuHwskPx/9oADAMBAAIRAxEAPwD/AFTREQEREBERAREQEREBERAREQEREBERAREQEREBERARFC3m7VIq2Wu1sa+5yx8o6WVpdDSx66cpIAQTqQQ1gILi08QA5wvTTNc4QnVLyysgjdJI9sbG87nnQD+9RzspsrSQbvQAjoNSzrUdFs/tEsoqLpEb/W8T2RdNJtCeHeMI3Ixpw0Y0f8ypEYtZQABaKDQDQDsZnUtcLGNZmf8Av+3HM/nbVZPHFB60zrTtqsnjig9aZ1r+9q1l8UUHqzOpO1ay+KKD1ZnUn9n2/snmfztqsnjig9aZ1p21WTxxQetM61/e1ay+KKD1ZnUnatZfFFB6szqT+z7f2OZ/O2qyeOKD1pnWnbVZPHFB60zrX97VrL4ooPVmdSdq1l8UUHqzOpP7Pt/Y5nRSXmguDt2lrqapd80MzXn/AJFdihKvB8dr49yosVulGmgJpWajjrwOmo48dQuJ1vrcPaaiglqrnaWamW3SudPPE38qBxO87TpjcXaj4hBAa5ks6+aief2/X/u9GEdS0IvlS1MVbTRVFPI2aCZgkjkYdWuaRqCD8xC+q59OaUCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAqxs/0rrPLe36Onu876sv/wCq13YG/VpE1n1a7x6SrOqxs1HIYVbaJ2okt7XW+QEaEOhcYj/cdzUHpBB6V0U81lVPtjx+kJ6lnRQWVZ3jWCwQTZLkNqx6GocWQyXWtipmyOA1IaZHDUgdAVdHugtlxYXjaTiBYCAXe/tLoCddB/OfUf8AgudCV2l7R7VsrxWS+3aOrqYRPDSw0tBFys9RPLII44o2kgFznOA4kD5ysy2m+6GvuL2jAa614JkDJL9kTbVV2+vpYGVUcYY9xYwGoazlJC0bjt5zC1j9SDu6zOeZ/hW1TD7pj+Pdre1qqmYx82M0N+pRLLCJGb8gdvndLNQ4HVvfBvfNOhWcQbMdpsey7HJqm21F1umOZuy/2zHrjd4561lra18bKV9W524+Vole4FzyNA1u8dEGuZxtq7Q6KiqqrBswuMUtCLhVG2UEU4t7NNXNmdyoaXt0OrYy88NRqNCeG9e6OsFDe7BabTZ77ldbfrIL/bWWSmjeKilLmgHWSRgYdHB3f7o04a7xDTnW1LZ3l+0XMhdLxs87Z7TXWCOkt9or7xAymsNeXycrLOzeLZCQ6LSWISOHJkAcxUjsK2WZZimWbPK292Y2+Cy7PO1yrkNTDJu1bKqAho3HkkOZEXggaAEA6O4ILLs922X7LNtudYdW4hdKW12app4Ke4blOI6cOpuVLqhwqHOPKOPwe4w96W7wadVsyxOgosh2abcM+v8AWWWKowrJG0VdNkJuNPBFahTUvJS8uyRzXbukYdvNBGhOumitg90JsscQBtKxAk8ABfqXj/3iDQEVFotvGzS5VkFJSbRMUqquokbFDBBe6Z8kj3HRrWtD9SSSAAOfVXpBWMS0tt3v9kboIKWdtVTMH9iKcFxb/dK2bQcwBaBzKzqsWAdl5plFa3Xk4xS2/UjQF0bHSu0+cfygDX5wR0Kzrot+nj7I/iMUzqIiLnQIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKtV0UmLXWqusELprZWEPr4YmudJHIAGiZjR8YboAcBx0a0jmINlRaUV5Z9k6phyU81De6OGpgfT19LIN6OaMtkY4fO0jUH+5fr3tpPzWH/DHUoiuwa1VVZLWQNqLXWykulqLbUPpzI487nhpDXn63AngPmXOcInJ4ZRfmj5hPEfvjWmWynSrDvj6HMsUVHBA7eigjjdppqxgBX2VW7SJ/Km/f48X4SdpE/lTfv8eL8JPJ2fr/tKcI3rSiyraDbrpjJxrsLKLyffC9U1BPyssR+Cfvb278GO+70afcrZ2kT+VN+/x4vwk8nZ+v8AtJhG9aHNa9pa4BzSNCCNQVz+9tGf/hYP8MdSr/aRP5U37/Hi/CTtIn8qb9/jxfhJ5Oz9f9pMI3rC230rXBzaaEEHUERjgou8ZEYqk2u18lWXtzdRCSSynBHCSbT4rfmHAu5h0kcnaIyYbtXfL5WR6aGN1cYg4a9JiDD/AM1NWmzUNipBS2+kio4N4vLIWhu8487j87j0k8T0phZUc+Oaf2/79P1RzQ/Fis0VhtkVHE50hBdJJM/40sjnFz3u+tziT/epBEWNVU1TNU6ygREVQREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERBnu2EgHB9SR/tRRaafok+taEs92w664Ppp4UUXPp80nzrQkBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERBnm2LnwbiB/tRRc45+Ei0NZ5ti01wbXyooujXokWhoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiKCyLJH2maGioqUV90qGukjgfJycbGN0BfI/R263UgDQEkngNA4i9FFVpOWnUTqKkm+ZhqdKGyadGtVN+Gv57+Zh+Y2P1qb8NdOy1744wnBd0VI9/Mw/MbH61N+Gnv5mH5jY/Wpvw02WvfHGDB5i92J7sKp2NbSbPi9dgktZTUFZSXykuQuTY21sbWuDmhhiduEPL266n4uvTovU2yTNq7aRs3sGUXGxvxypu1MKoW2So5d0UbiTGS/dbrvM3Xcw03tOjVYzt92BVPuhpcWlyCjtEMlirhUh0NRLrUQnTlKdx3ODXbrePRodOda3Fd8thjZHHb7FHGwBrWNqJgGgcwA5NNlr3xxgwXlFSPfzMPzGx+tTfhp7+Zh+Y2P1qb8NNlr3xxgwXdFSPfzMPzGx+tTfhr9DLr7aWuqbxbKJ1vjBdNLbqiR8sTRzu5NzBvgcSQDroOAceCbLadWE/rBguqL8xyMmjbJG5r2OAc1zTqCDzEFfpcaBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAVHrzrtMqgei0QafVrNNr9wV4VGr/6zav9T0/76ddl21q7vGEx1pZERboEUPf8utOL1VmprnV9jTXitFvoW8m9/LTlj5AzVoO73sbzq7QcOfUhTCgERFIIiIC5bsA61VgIBBhfqD/9pXUuW6/JdZ9i/wBkq1PSgSGCOL8Ix5zjqTbqck/9k1TqgcC8Bcc/VtN+6ap5cFt6SrvlM6iIixQIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgKjV/wDWbV/qen/fTq8qjV/9ZtX+p6f99Ouy661d3jCY60ssT2pUFVk+3rBccdfr5arPVWS61NTBZrnNRcu+OSlDC50bge933aEEHiRroSDtiyfabsOp9qO07FrzdmsmsNqttdSzQxVk9NUmaZ0BjdG6ItIAEbwe/HxhwOp01q54Qx6gv1zuNww203K61F8hxzazPZqK51jw+eeBlvnc0SP4b72OkdGXc53OPHVfja/mWQw3vJs2w+syOO343fqS21dTWZAYre6Vs0EU9PFbxG4Ss+E0L3ua7ecS0kNAXoObYhg0+EUGIHHadmPUE7aqlpInvjMMzXFwlbI1weH6ucS/e3jvHUnUrgyL3OmzvK7ndK+644yqnubzLVs7LnZDJLuhvLck2QMbLoB8K1of072qplnAY3m3v7cIPdB36LMcjoKnEJnVVmp6O5Pjpqd8dtgnIMY4SMc4cWP3mcXENBc4mU5O7bTs+z9lTlWQ2eloMYtFxo6Wz3OSlihqZoalzpNGnU6GNve67rv7TXaDTbpNl2MTW/K6GS2ufTZS0tvDXVMpNUDA2A6u39W6xta3VhHNrz8V97Zs7x6zXC51tHb+RqrlRU9uqn8tI7lIIGvbEzQuIG6JHjUaE68SdApyjzBb87z/AGyXPBbHTTTO38Hocgqo6XIZbFJWVMziySXlYYJXOY0sHeDdaDJx3uAFhmsu0B2U7H8Ry3K7hRS1b752dJZLpIJKuljZG+nZLM1ke9I1pDTIGNdwcRulxK167e5/wG92PH7TVWH+S4/AKW2SQVlRDUUsIaG8m2dkglLSANQXHXTjqpq37MMYtU+NTUlrbBJjcM0Fq3JZNKZkrQ2Qab2jt4NHF2p6RxKjLPWLFQUbbdQ01IySWVkEbYmyVErpJHBoABc9xJc46cSTqTxK/F1+S6z7F/sldS5br8l1n2L/AGSt6elA78C8Bcc/VtN+6ap5QOBeAuOfq2m/dNU8uC29JV3ymdRERYoEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQFRq/wDrNq/1PT/vp1eVWMmslb75w3m2RsqqpkJp5qR79zlo9d5u648A5p15+BDiNRwK6rvVFNUxPXGCYfRFCuut/DiO065u06RVUeh/75fz32v/AJG3P1qj/HXb5P8ANHxU/VOCbRQnvtf/ACNufrVH+Onvtf8AyNufrVH+Onk/zR8VP1ME2iqV6ze4Y92B2fil0g7Oq46Kn+HpXb8z9d1vCY6a6HieH1qS99r/AORtz9ao/wAdPJ/mj4qfqYJtFCe+1/8AI25+tUf46e+1/wDI25+tUf46eT/NHxU/UwTa5br8l1n2L/ZKjvfa/wDkbc/WqP8AHSSLIb/BJQiyTWSOdpjkrKyoheY2kaEsbE9xc7QnTUgA8T8xmKcs4zVHGPqYLBgXgLjn6tpv3TVPL4UNHFbqKnpIAWwwRtiYCddGtGg/5BfdeXaVZq5qjrlEiIizQIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgz7a+NThHD/5noujXok+orQVnm2LTXB9dPCii59fmk+ZaGgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIM92w8+D/AP8AKKL+1p0Sf8f0LQlne2PTXBtSR/tRQ6aDXokWiICIiAiIgIiICIiAiIgIiICIiAi/EsrIInySODI2Auc5x0AA5yVADaLi5GoyG26edM61lXbWdl6SqI75wTETOixIq73RMX8oLb60zrTuiYv5QW31pnWstru/aU8YTlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncsSKu90TF/KC2+tM607omL+UFt9aZ1ptd37SnjBlncru2MgHBtQDrlFDz9HCRaIsf2uZ5jtQcK5K/W925k1E9+7UtOjQH6k6HmV+7omL+UFt9aZ1ptVh2kcYMs7liRV3uiYv5QW31pnWndExfygtvrTOtNru/aU8YMs7liRV3uiYv5QW31pnWndExfygtvrTOtNru/aU8YMs7liRV3uiYv5QW31pnWndExfygtvrTOtNru/aU8YMs7liRV3uiYv5QW31pnWndExfygtvrTOtNru/aU8YMs7liRV3uiYv5QW31pnWndExfygtvrTOtNru/aU8YMs7liRV3uiYv5QW31pnWndExfygtvrTOtNru/aU8YMs7liRRFsy6yXqq7GoLtR1lRul3JQTte7Qc50B+sKXW9FpRaRmomJj2Iww1R2R+D1081l9grlx75AtnmsXsBdWR+D1081l9grlx75AtnmsXsBeHf/T093i0o0SCIi4VxERAREQEREBERAREQEREBERAREQQOTZ/i+FPpmZDklosL6o6QNuddFTGU/MzfcN7+5fXIs0x7EKCGuv1+tlkopnBkVTcayOnjkcRqA1zyASR0Bef/dG3+iqdp9LjeQV9Di9lkx988F0kskNwrLpO+VzH0MBljkaNGtY4sa0vdyjdNNNVj9pzi3YLiuwjJr/Far/CMRrbC+1ZBVNpY6WZkkLHyCSVpZvtMfIvZ8fd10BAdp002OaIlWZe1qjaTiVHjkeQVGUWamsMkjoWXSaviZSueHOaWiUuDSQ5rhprzgr61WfYxQ2ykuVTkdpp7dWMdJTVctdE2GdjWlznMeXaOAaCSQeABK8XQ45R4TBscnvmdx02CUmO1tLT5TZqamuNuprjJUiR0e9UQzMY3k9YmSFrXfBFuo1cFc7LgmK0GSbEWWa6T5bYLvll4uzJrpRRQsMvvfPqY4WQxMYwSxco3dYBqd4cCCpmxpjr3+Ji3jPdvmF4DglJl9Re6G4WSsrIKGmqqGthfHM+SQM1a8vDSGDee7QkhsbzpwV2sl8tuS2qnudouFLdbbUt34KyimbNDK3XTVr2khw1BHA9C8gZpbYqPBNuDKeh3rZaNoltuclPTwb4hhb73TVEjWNHMG8o92g5t4/OvWeHZNY8wxyju+N1lNcLLUbwp6ik/mnhri127+hzSP7lnXRFNMTH/aJicU0iIsUiIiDPtsB0OEcQP9p6LnGvRItBWf7XtdcJ0JH+01Fza8eEi0BWnowgREVUiIiAiIgIiICIiAiIgg6/w1sH2FX90as6rFf4a2D7Cr+6NWdevyd0K/e+WlnXqjsj8Hrp5rL7BXLj3yBbPNYvYC6sj8Hrp5rL7BXLj3yBbPNYvYC5r/6enu8U0aJBERcK4iIgIiICIiAiIgIiICIiAiIgIiICpu0DZu/O5qCaHLclxaakD2h2P1rIWzB2mokZJG9jtN0aEt1Gp0I1KuSKYmYnGBW9nmz+07McVprBZhOaSKSWZ0tVKZZppZHukkke887nPc4nmHHgAOCsiIomZmcZBfN9RFG4tdKxrhzguAKrua1cu9Z7ZHM+Blzq3QTSROLH8k2GSRzWuHEF24G6jQgF2hB0Kju0DGCBrjlpd9bqKInn1P8AZ+ckr27pydFvZxaWleGOmEY+MImYjVcuy4Ppo/TCdlwfTR+mFTe59i3k3aPUIv4U7n2LeTdo9Qi/hXZ5ose0n4Y+5GaFy7Lg+mj9MJ2XB9NH6YVN7n2LeTdo9Qi/hTufYt5N2j1CL+FPNFj2k/DH3GaHh7/0imwG5XbafjOXYwySrkyaeG01UUT9d2sADIXc/AOjAH/Zn517h2PYHbtkezHHcQpKpk0drpRE+Yya8rK4l8r+PHvnue7To1TufYt5N2j1CL+FO59i3k3aPUIv4VvXydZ10U0TaTzflj7lcaYnFcuy4Ppo/TCdlwfTR+mFTe59i3k3aPUIv4U7n2LeTdo9Qi/hWHmix7Sfhj7ls0Ll2XB9NH6YTsuD6aP0wqb3PsW8m7R6hF/Cnc+xbybtHqEX8KeaLHtJ+GPuM0Lsx7ZGhzXBzT0g6hf1Z9cbXQ4Z2Lc7PSQWx4q6eCeKljEcdRHJKyIh7WjQkBwLTzgtA1DS4HQV5N8ueyzGFWMT+mnFMTjGIiIvOSIiICIiCDr/AA1sH2FX90as6rFf4a2D7Cr+6NWdevyd0K/e+WlnXqjsj8Hrp5rL7BXLj3yBbPNYvYC6sj8Hrp5rL7BXLj3yBbPNYvYC5r/6enu8U0aJBERcK4iIgIiICIiAiIgIiICIiAiIgIiICIiAiIgqWaeEGIefzf6SZSqis08IMQ8/m/0kylV9ncfwtn+v/qWdfUIiLtZiKsbRtoVs2YYxJe7rHVVEInhpYaahi5SeomleI442NJALnOcBxIHzlZvtI2+3vGrVgtbbMHvzZL5kDbXVUFdTQMqo4wx7ixgM4byjy3vHbzmFrX6kHd1rMxA29FneabY+0ejo6mpwnLbhFLRCvqjbaGKYUDNNXNmdyoBe3Q6tjLzw1Go0J4rx7oWxUV5sVrtVoveU1l8swvtuZZqaN4nptWjXWSRgYdHB3f6Do13iGljA1FFkGBbZb5lO2bN8RrMTuVNbLPUQQU9fuU4jgDqblSZyJy48o495uNPelu8GnVa+picQREUivZ38gR+f0P8Aq4VeVRs7+QI/P6H/AFcKvK8LlboWffV8ranoiIi+cWEREBERBB1/hrYPsKv7o1Z1WK/w1sH2FX90as69fk7oV+98tLOvVHZH4PXTzWX2CuXHvkC2eaxewF1ZH4PXTzWX2CuXHvkC2eaxewFzX/09Pd4po0SCIi4VxERAREQEREBERAREQEREBERAREQEREBERBUs08IMQ8/m/wBJMpVRWaeEGIefzf6SZSq+zuP4Wz/X/wBSzr6kJk+b45hMME2RX+12CGdxZFJdK2OmbI4DUhpe4akD5lADbzszLC8bRMTLAQC737ptATroPj/Uf+Cu0sEU4AljZIBzb7QdF8/e6l/Nof8ADC7Odmy/OM7w3adiVysNg7XdqlVMxjpsbor5SiSWESN3pAd/vSzUOB1b3wb3zToVnsOzbaRHs0x6aot1Rc7nj2ZsvtusFwusc1Yy2Na+NlK6qcdx8rRK9wLnkaAN3jovSsVJBA7ejhjjdppq1oBX1VcuOo83bTNn+WbQcvFzu+A9slrrrEyloLTXXaBlPY64vk5WWdm8WyEh0WkkYkcNwgDpUhsR2ZZVi+U4BWXmzmggs+Adr1VIamGTdq2VMJDRuOJIcyIvBA000B0PBegUTLGOIxqho7/s52051fauzxz4bkTaOtmv5uEEEVsFPS8lLy7JHNdpowO3mgjQnXTRWobe9mTiANouJkngAL5S/wAavTmh7S1wDmkaEEagr4G3UhH9Fh/wwpwmNBUaPbhs5uNZBSUmf4vVVU8jYooIbzTPfI9x0a1rQ/UkkgADnV2XwbQUzXAimiBHEEMHBfdTz9Yr2d/IEfn9D/q4VeVRs7+QI/P6H/Vwq8rw+VuhZ99XytqeiIiL5xYREQEREEHX+Gtg+wq/ujVnVYr/AA1sH2FX90as69fk7oV+98tLOvVHZH4PXTzWX2CuXHvkC2eaxewF1ZH4PXTzWX2CuXHvkC2eaxewFzX/ANPT3eKaNEgiIuFcREQEREBERAREQEREBERAREQEREBERAREQVTN2cnc8WqnndghuLmPeeZpkp5WM1PRq9zWj63NHSpNfvKLnZ7RYK2pv89LT2gRllQ6sI5JzXd7ukH429roG8SSQADqswhwe5Z7WQzUEl9wvGWObIyaS51bLlWjXe3RTyO3aWM8x5RrpSCRuQkBx+iuV+srOxiztcYw64iJ9u+FZjFpiKN7mto/Ob3+3a38ZO5raPzm9/t2t/GXb5yum+r4Y+5GT2pJFG9zW0fnN7/btb+Mnc1tH5ze/wBu1v4yecrpvq+GPuMntSSKN7mto/Ob3+3a38ZO5raPzm9/t2t/GTzldN9Xwx9xk9qSRRvc1tH5ze/27W/jJ3NbR+c3v9u1v4yecrpvq+GPuMntSSLx37veXOtillx7LcFyi90FlfK6huNI+vmna2U99FJq9znDUB7ToQO9b0laT7kq15VtJ2S0WUbQKmqhqbkeUoaakuVxgmbACQJJt6fTWTQOaGt03C128d/Rm0366xZxaY1Yd0fcrljHBrmaM7IttFStOs9RcaNsTBzuLahkjtB9TGPcfmDSehXdQ9nxG2WOpNTTxTSVRZyfZFXUy1MjW8NWtdI5xaDut1A010BOuimF8/f73ReZpizicIx115+O5pEYRgIiLykiIiAiIgg6/wANbB9hV/dGrOqxX+Gtg+wq/ujVnXr8ndCv3vlpZ16o7I/B66eay+wVy498gWzzWL2AurI/B66eay+wVy498gWzzWL2Aua/+np7vFNGiQREXCuIiICIiAiIgIiICIiAiIgIiICIiAiIgKpZJnhorlJY7BQ9sOSgNL6JknJwUjXAlslVNuuELTpqBo6Rw1LGOAJEfPfbptFlko8ZqTbceaSyoyWMtdJOQdHRUbSCDzEOnd3reAY2QkujtWOY1bMTtjLfaqUUtM1xe7vnPfK8/Gkke4l0j3Hi57yXOPEklWwiNRA2XZ6Ddob7k1YMiv8AC5z6Z8kQZS2/UaEUsPHcOmoMji6Q6kF26Q0XFEUTMzqCIigEREBERAREQRGVYjZs4s77Tf7bT3a2PlimfSVTN+N7o3tkZvDpG80ag8CNQQQSD+LtjomrJrrbOQob++GOm7OdFvcrCyTlBFIARvN4yAE8Wcq8t0LnazSKcZHBbbu24SVET6aooZ4ZpIuRqmhrpGtI0lYQSHMcHMIIPDe3XBrg5o71G3mysuginjMcFzpQ80dY6PfMD3MLSdNRvNIPFuo10HMQCFju3vlHUQyb4raKTsep3oHwtc8NB3mB2urHBwIILhzjXVpAdwkkRFAIiICIiCDr/DWwfYVf3RqzqsV/hrYPsKv7o1Z16/J3Qr975aWdeqOyPweunmsvsFcuPfIFs81i9gLqyPweunmsvsFcuPfIFs81i9gLmv8A6enu8U0aJBERcK4iIgIiICIiAiIgIiICIiAiIgIiICol9qpc5yubFqWaSCz25jJb3PC8tfK543oqNrgQW7zdJJDz7hY0fzhLb2qFsb1qbHkFwedZ6zJbxyjt8P15GumpmcR80dOwadGmnQrRzRMi8UtLDRU0VPTxMgp4WCOOKJoaxjQNA0AcAAOGgX1RFUEREBERAREQEREBERAREQFAXZstBk1or42XOqjqd+3zQU0gdTQggyNqJYzx1Do+TDm/Td8CACyfUBnsEk2JXGSGkra+opWtrIaS3z8hPPJC8SsjY/m1c5gGh4EEg8CVMaifROdFAIiICIiCDr/DWwfYVf3RqzqsV/hrYPsKv7o1Z16/J3Qr975aWdeqOyPweunmsvsFcuPfIFs81i9gLqyPweunmsvsFcuPfIFs81i9gLmv/p6e7xTRokERFwriIiAiIgIiICIiAiIgIiICLgvl4hsFrnrp2vkZHutbFHpvyPc4NYxupA3nOc1o1IGpGpA4qvPqMwqAHtrLJQ73HkHUU1TufVynLR72nHjujX5gu+73K1vNM1U4RG+TmjVcEVM3sz8cWL9kTf8Amk3sz8cWL9kTf+aXX5ptvWp/f6Ixje/u2PPK/ZhsyyDK7bYnZLVWmn7KNsZUcgZYw5vKHf3H6brN9/xTruacNdV529w97pu6baqu/WKHC/e21UVXX3epvD7oZgx9ZXTVEdOI+RbqQJXN13hqIidBqGr0LPDl1VBJDNdMfmhkaWPjfZpnNc0jQgg1XEEKg7Fth1VsEx2us2LXK0spqytkrppKq1SvkLnaaN3hUDvWgANHQOkkknenkuuLOaZmnHvn6IxjHVuiKmb2Z+OLF+yJv/NJvZn44sX7Im/80sPNNt61P7/ROMb1zRU1rsxDhvXexluvEC0TA6etKRsN/q5bi61XaOBlwEJqIpqYnkqiMENcQ0kljmuc0FpJGj2EOOpDcbbk62saJrxiYjXD/cQYxOiwoiLy0iIiAiIgIiICIiAuK+UTLlZbhRyMkkZUU8kTmRP3HuDmkENd0HjwPQu1EEXizpH4xaHTUtRQzGjhL6WreHzQu3Bqx7hwLhzE9JBUoq9s7o227A8eo2UNZbWU1BBA2juEvK1ELWMDQyR+p3nAAAnpVhUzqCIigEREEHX+Gtg+wq/ujVnVYr/DWwfYVf3Rqzr1+TuhX73y0s69Udkfg9dPNZfYK5ce+QLZ5rF7AXVkfg9dPNZfYK5ce+QLZ5rF7AXNf/T093imjRIIiLhXEREBERAREQEREBERAREQVbaO4tsVGQSD7628cPO4lIqN2kfINH+trd/q4lJL6/k38JHvT/FLOvqERF6LMREQERcNpvlvv0M01trYK+GGeSmkkp5A9rZY3FsjCR/aa4EEdBBCDuUK9xG0WxN1O6bdXEj/APOlU0oST+sew/q6v/eUqytvRV+7V/Er0armiIvhGoiIgIiICIiAiIgIiIK7s9pewsLtNOKCrtYih3BSV03KzRAEjRz+k9Ov1qxKvbP6Y0eIW6F1HW28sa8djXCblZ2d+74z+nXnH1EKwqZ1kERFAIiIIOv8NbB9hV/dGrOqxX+Gtg+wq/ujVnXr8ndCv3vlpZ16o7I/B66eay+wVy498gWzzWL2AurI/B66eay+wVy498gWzzWL2Aua/wDp6e7xTRokERFwriIiAiIgIiICIiAiIgIiIKrtI+QaP9bW7/VxKSUbtI+QaP8AW1u/1cSkl9fyb+Ej3qv4pZ19SnbYsoocN2Y5FdrjUXGlpYaUsMtoIFYHvIjYISeAeXvaATwBIJ4LzbDf9qGATbSbBRm6C5Nw5l9tdDc74b5U003LSRPc2V8bTvboJ5Lv27zBoSHaL1jkmOWzL7FXWW80UVwtdbEYaimmGrZGno+cfOCOIIBCzqv9zlh9DZL4LFY6cXm4WqotZqbrWVdQ2ojkA+DqHmXlJGAsbp32rQO9LdV3VRMzzM2C1OeXPDbdnOZ4DkeT5ZjVuw5j4bhkVTUzxQXKWdoLmNlADi2ICRwDSGaaDdDi1XnHMR2o4zO68Pukgx59orH3B1Vl814fUONO50E1O19LEIXCQNPwbg3dcdG8ApvZFsJyTGMnravIZ7fT49U22WgqMeo7xcbtTVrnub8LL2a47mjQ5oa0HUSHUnpvmJbA8FwaSrfZbI6lNVSPoHh9dUTNZTvILooxJI4RMJA4M3RwHzKsUyMb2e1F7sUGwC+yZZkF2nzKlbT3mC5XF88E2/bX1DXMjPexuY+NujmAOI13i4klWf3I2G0lix/J66G4Xepm7Y7vROhrbpPURBsdbIA7k3vLRIQAXP03nEkknUrVqbZjjVJR4lSxW3cgxQNFmZy8p7F3YHQDiXav+Dc5vf73Prz8V87BsrxfF8uuuTWq2uobxdC91ZJFUzclK55aXv5Hf5MPcWNJeGhx04niVMU4C2KEk/rHsP6ur/3lKptQkn9Y9h/V1f8AvKVRbeir92r+JXo1XNERfCNRERAREQEREBERAREQV3Z9SiixC3wiirbcG7/8muEvKTs+Ece+d0684+ohWJV7AKR1DiNBA6hqrY5gfrS1s/Lys1kce+f068/6CArCpnWSBERQCIiCDr/DWwfYVf3RqzqsV/hrYPsKv7o1Z16/J3Qr975aWdeqOyPweunmsvsFcuPfIFs81i9gLqyPweunmsvsFcuPfIFs81i9gLmv/p6e7xTRokERFwriIiAiIgIiICIiAiIgIi4L1eqew0Jqqhs8o3msbFSwPmle5zg1oDGgnncNTzNGpJABICF2jtLrFRgAk++tvPDzuJSKjbvjtxzCnlgudQ60U8FcZaZlvkbI6djADC+Uvj70iQcoGt6Wx6uI3mn4P7bafSP3ptdaW8OXjuD4g/69wxOLdePe7ztPnK+o5Ot7Kmw8lVVETEzPPOGsRv7laomdEyig+Xy3yet37Wd+As22ke6NpdlmT4/jd6ore+/3yqjpaW3UlzMsrd9waJJByIDGakcSdTx0B0OnqxaWdU4RXT8UfVTJLZUUHy+W+T1u/azvwE5fLfJ63ftZ34Cr5Wy9en4o+pklOIoPl8t8nrd+1nfgL+OqMua0kY7b3EDmF2PH/uU8rZevT8UfUySnVCvae6LYjodBbq4a/wD50q5LXdcruVJFMcaoqV7gOVp5btrJC7QEsduxEbw16CR8xI0KnLFYqwXM3e7cg2uEJp4aeleXxwRuLXP78taXuc5jdToBoxoA5y7mvN4sqLKv+uJmYmOaYnWMOpammYnGVhREXxq4iIgIiICIiAiIgIiIK9s/ove7ELfT+9s9o3A/+RVM/LyR6yOPF/Trrr/forCq7s9oxQYfb4G26ptIYH/yOsm5WWPWRx753Trrr+ghWJTOskCIigEREEHX+Gtg+wq/ujVnVYr/AA1sH2FX90as69fk7oV+98tLOvVHZH4PXTzWX2CuXHvkC2eaxewF1ZH4PXTzWX2CuXHvkC2eaxewFzX/ANPT3eKaNEgiIuFcREQEREBERAREQEURfMjitLJ4aeF10uzIRPHaqWRgqJWl4YCA5wAbvHQucQBoePBfKTHHXWsdLeZmV0EFayroKaNjo2U5Y3Rpfo74V28XP77vQdwhocwOM4bx8G3ypyimidj7mC21UFQBeXf+6kaTGwxxOHwoLg528dGlrQQXBwKkbTYKa1PM41qrjJDFBUXGdreyKkRt0aXloA6XHRoDQXuIA1KkkTHcCIigF/nnc/cMZFk236ry3EswF5tlnvtO6sq8rqHmrmnjEUs4ZJFEWyBpcW6kMAcC3jukr3VtByp+GYhcbrBT9m1zGthoqTXTsmqkcI4Ivq3pHsbr0a69C+mCYsMLxG2Wc1DqyenjLqmrf8apqHuL5pnfW+Rz3n63Fb2dpVZRM09aJjFPIiLBIiIghbjan0Va+7WyGFlW7Q1scdO10tdGxjtyMOL2APBI3XOJAGoI46iSt1dHc7fTVkLZmRVETZmNqIXwyBrgCA+N4DmO48WuAIPAgFdCga+mksVdJdKNkZpp3b9zE08veRsY7SWJgDm74IaC0Bu8OJdqwAzqJ5F8aKtp7lRwVdJPFVUlRG2WGeF4eyRjhq1zXDgQQQQRz6r7KAREQEREBERAREQEREFd2fUoosQt8Io623hof/JrjLyk7PhHHvndOvOPqIViVe2f0vYWIW+HsKst26H/AMmuEvKzM+Ece+d0684+ohWFTOskCIigEREEHX+Gtg+wq/ujVnVYr/DWwfYVf3Rqzr1+TuhX73y0s69Udkfg9dPNZfYK5ce+QLZ5rF7AXVkfg9dPNZfYK5ce+QLZ5rF7AXNf/T093imjRIIiLhXc01yp4JCx8mjhzjdK/HvvSfS/5T1KFu7g2unJIAGhJPRwCzvGNuGE5ne3Wqy3sV9SBIWyspZhTyBnxzHOWCJ+mh13XFetRdKKqYqmZZZpa9770n0v+U9Se+9J9L/lPUsgxTblg+b35lnst+jrK+Vsj4GmCWOOqaz45gkewMmDekxudw48y+GMe6AwHMrja6Kz38VUt0B7CkdSTxw1Dg0udG2V8YYZAAdY97eGh1AIV9is98maWze+9J9L/lPUnvvSfS/5T1Lz5hvukLJlhzRslLX292PVdVEHG11sjJIIRGOUJEI0eXPPwI1foNdCOK7bLt5x6ixHEqzI71SPu1+tvZ9Oyz0NXIysa3c3zTxGMynTlGncI39NTpo1xDYrPfJmlu3vvSfS/wCU9SjbjfZpKmlgoOS7HkMjaqrkcQ6ABh3TGzdIe4vLeB0AAdx1Aac9tW1bFMhZjTqC8R1UOSPmitZjik/lD4WvfK0978GWtjfqH7p1BHPwX7uG1fE7VTZBPWXmKmisFSyjuLpY3t5KZ7GPZG3vfhHOEjNAze1LtBx4Kdjs/aZpaDZ222z00TG1ElVUthZDJW1I3qicM10Mj9BqdXOPQAXHQDVTUUrZo2vYdWu5isqwjaVje0WOsdYLj2XJRuaypp5oJaeeAuGrd+KVrXtBAOhLdDodOZabbP6BD+hcl5sKbKmJhamcXUiIuBcRFCZnlMOGYzW3eaF9U6FoZBSRECSqne4MhgZrw35JHMY3Xhq4JEY8wrNyb267VqGhBD7TibRX1PMRJcJY3NgjP2cL5JC0jnmgcOLVoKrWz3FpcUx1sNbK2pvFZNJXXKpYdRLVSnefukgHcbwYwHmYxg6FZVaqeqAREVQREQF+XvEbHPcdGtGpP1L9L41v9Dn+zd9ymmMZiBA01eLVd5GtmqqygrX77W8nGI6AhnEa964teRqBo8hxdxDSA2Y996T6X/KepZ/mWZ2PBLK65ZBXMoKEvbC0ua575ZHfFYxjQXPceOjWgngeHBVqHb3gbsbmvj8ihgtsFYygmknhmjkgmfpuMljewPjJ1Hx2gcdddF7Ox2c72WaWy++9J9L/AJT1J770n0v+U9SyzH9reJZLbbzX0d3bFT2Yb1y7Pglo30jd3fDpGTNY5rS0EhxGhAOhOip2Je6Ete0Ha9b8axuoirrLLY6m5zTzUVRTziRk0LI9zlA0Ojc2R51DSCQNHcCFGxWe+TNL0XT1MdUwvidvNB01004r6qNsP9Df9ofuCkl5drTFFc0w0jngREWSRERAREQV7Z9S9hYhb4eway3bof8AyWvl5WZnwjj3zunXnH1EKwqu7PqYUeIW+EUVbbw0P/k1xl5Sdnwjj3zunXnH1EKxKZ1kgREUAiIgg6/w1sH2FX90as6rFf4a2D7Cr+6NWdevyd0K/e+WlnXqjsj8Hrp5rL7BXLj3yBbPNYvYC6sj8Hrp5rL7BXLj3yBbPNYvYC5r/wCnp7vFNGiQREXCuzvavYqvKMRyuzUE4pq6422oo4JidBHJJC5jXa/USCsXxK9XDJ9kQ2aNw7I8Wvna5LZ5KiqtxioKWZtKYg5tQDuPaXcWlm8TrxAXpKvtdRUVckjGgtdppx+pc/vNVfkN9IL3rO2s4opiao0YzEvLWPsvOay7G8egwy943UYdURVV2rLjRGCmp2w0ckBhhlPezCRzxoYyRujU6LnxbD77TbDNg1DJZLjFcLZkdFPW0zqSRstJGOyA98jdNWNAcNS7Qd8PnXq33mqvyG+kE95qr8hvpBa+Xs/WhGEsC2cyXDGMm2mYzcLBeGTXW91t3orjHQvfQzQSwR7vw4G6H6sc3cPHXT51Wdj+I3u3XXYY6ts9wo2W7DKylrXTUr4+xZiaTdjkJHePO67vToTun5l6j95qr8hvpBc7bXVGvki7GeNImu5YkbjuLhujjzjTU/pCeWs/Wgwl5Rs+O33ErnjuS1GO3ie32XPciqKimpKGSWobS1QqY4p44QN58er2nVgOodqNQoTJMQyXL6nKMljxfJoKCmzqjvT7ZFytDcKuibb2QOlpy1zXF7S7eDWuB4Fp0cCF7R95qr8hvpBPeaq/Ib6QTy9n60GEsa2L4/j5uV4yK2WbMLfXTxxUMlXmE9W6eoiZq9oY2pkc8Na57ucN4k6arfbZ/QIf0KH95qr8hvpBTdFE6CljY8aOaNCuC92lNdMZZxXpicX3REXltBZ/QOG0XO3XHXlMcxqeWnpQWgsq7kCY5pQelsHfwj/rHTajWNpXZtDvdbM+kxOxVL6W/wB6ZIOzIgHOttK0aS1Z14bw1ayMEHWR7NQWNfpZ7LZqLHbTSWy3QCmoaSJsMMQJO60DQakkkn5ySSTxJJVo/pjEdqIiqCIiAiIgL41v9Dn+zd9y+y+dSwyU8rG/Gcwgf8FanmqgeZvdI4lcbtccDyCnob1drTYbjPJcqLHamWCv5OWB0TZoTE5r3Fjjxa06lrnDQjVU274Pb6zHKC+Y3jeYQ1dVmNjfXyZL2XUVk1PTVDHcsWzPfIyJjXv1Lg3gw6jQAr1b7zVX5DfSCe8tV+SPSC+h8vZ+tDDCXlbbRs8yPKsl2sNtNnqKtlZZrDLDG5hZDcTTVc0s1O15G65xjG7pr/baDwKsuL5BV577oSxX6DFckslqpsWraSSe92qSka2Z1TTOEWruG9o1x+Y6HQnQ6bljkseT2OjultmFXRVLN6OYtMe+AdCd1wBHEHgQpL3mqvyG+kE8tZ6ZoMJSFh/ob/tD9wUkuK1UslJTuZIAHF5PA69AXavCtpiq0mYbRoIiLFIiIgIiIK9gEPY+I0EfYldQ6B/8nuT9+oZ8I74x6decfUQrCq7s+g7GxC3x9jXCj3Q/4C6yb9S34R3xz0/OPqIViUzrJAiIoBERBB1/hrYPsKv7o1Z1WK/w1sH2FX90as69fk7oV+98tLOvVHZH4PXTzWX2CuXHvkC2eaxewF1ZH4PXTzWX2CuXHvkC2eaxewFzX/09Pd4po0SCIi4VxERAREQFXcpoRTVttv8AT21tdcaBxp991X2PyVJM+Psh2pO64NEbJN13PyQ0IOisS+dRTxVlPLBPEyaCVpZJFI0Oa9pGhBB4EEdCROA+nOizJ21nE9l9RacTyjIbJarzPWsttqtdHNJJM+B7y2kLojvPZ3ga10jvgw4HvhqANNUzTMAiIoBRmTZFS4pY6q6VjZZIYANIadm/LM9zg1kUbf7T3vc1rW9LnAdKk1nuP/8AtNyaLJpO/wAZtUj2WOM/Fq5xvMkrj87NN6OE8xaZJBvCSMtmI65EtgONVltirL1eww5PeSyWu3H77KZjQeSpY3aDWOIOcNdBvPdI/QF5CtiIkzjOIIiKAREQEREBERARFD5TmWP4NbmXDJL5bcfoHyCFtVdKuOmidIQSGBzyBvENcdNdeB+ZIjHQc+A3Jl3xKhq2XaS+Mk5TSvlp+QdLpI4cWaDTTTd5uOmvSrAs82RbV8Tz60wUdlzy15hdYo5Jpux6iEVXJiQt33wMdqxo1a3UjQ96elaGrVRMThJAiIqgiIgIiICIiCu7PoOxsQt8fY1xpN0P+Busm/Ut+Ed8c9Pzj6iFYlXtn8BpsRt8RprhRlof8DdJOUqG/CO+O7p+cfUQrCpq1kgREUAiIgg6/wANbB9hV/dGrOqxX+Gtg+wq/ujVnXr8ndCv3vlpZ16o7I/B66eay+wVy498gWzzWL2AurI/B66eay+wVy498gWzzWL2Aua/+np7vFNGiQREXCuIiICIiCIvOWWqwTsgrKotqHN3xBDE+aTd499uMBIHA8dOOh+ZRvdMsH0lf+yqr8JcGFu7Jt9bWvG9U1NwqzLIeLnbk742DX5msY1o+YNCsC+sp5Lu9MYWk1TPXhMRH8SrNWE4P88Mz9ytLi3uksVzTFK675Pjc9+guFy98aWpdW0XwzXyPe+Rms7ec73F/OCD8Y+/u6ZYPpK/9lVX4SkUW9pcbtaYZs3N7Y+1WKojqR3dMsH0lf8Asqq/CTumWD6Sv/ZVV+EpFFl5sun5uMfanPG5QM8zimyl1Fj1I650lnrd592uUdvqmPbTtLdaaPRm8HzalpeB3rBIQ5rzGVa6baLjFHBFC2eS30sTQxpmoJ6eCJoGgG86MNa0D5yAApRFM8m3TDD+rjH2ozxuS7XB7Q5pDmkagjmK/qq2zx5bbblSN4QUdxqIIWdDI97eDR8wG8QB0AAdCtK+YvFj5C1qssccJaCIi5wREQctzutHZaJ9XXVMdJTMIBkldoNSdAB85JIAA4kkAKA7plg+lrj9YtdUR+7XxvEhqdoFDBJ30VNb5KiNp5hI6RrC79IaCAfmc4dJUuvpLrydY12NNpazOM8/NMR4SrNWCO7plg+kr/2VVfhJ3TLB9JX/ALKqvwlIourzZdPzcY+1GeNyO7plg+kr/wBlVX4SoG3ekxPbZsqv+I1j6xr62Amlnfaqr4Cob30T/wCa4aOA106CR0rUEUxybdaZxjNxj7UZ43PJnuDtmdBsFwa51+T01ZS5feJyJohbqiQ09PGSI2BzYyO+OrzoelvSF6i7plg+kr/2VVfhKRRWr5PutpVNVWbjH2kVRHUju6ZYPpK/9lVX4Sd0ywfSV/7KqvwlIoqebLp+bjH2pzxuR3dMsH0lf+yqr8JSlkyi15EZW0FWJZYdDJC9jo5WA66FzHAOAOh0JGh0PzFfhQWRPNJdMcqo+9nFxbBvDnMcjXNe0/Ue9OnztaegLO05Lu80T5PGJwnWYmOb9ITFWM4LqiIvlVhERBXdnsDafD7fGyluNG1ok0guzt6pb8I745/5j6iFYlXdn0YixC3tEV1hAD+8vR1qx8I7+cP3fVorEpnWSBERQCIiCDr/AA1sH2FX90as6rFf4a2D7Cr+6NWdevyd0K/e+WlnXqjsj8Hrp5rL7BXLj3yBbPNYvYC6sj8Hrp5rL7BXLj3yBbPNYvYC5r/6enu8U0aJBERcK4iIgIiIKNgfg+/z+u/1cqsKr2B+D7/P67/Vyqwr9Dr6UsaulIiw7Z5tNzGr2nbU6bIaKgjxKwXHcbWe+Gr6GFtHHK0NiEA5QPDuUcS/VpeWjeDQT9sa90RcLlPidfesLmx/EssmbBZrxJcGSyuc+N0kHZEAaOSErGEtIe/QkB2mqyzQq2tFh1l90pV3SOw36fDZ6PZ/frky22/IHV7HTOdJIY4ZZKXcBjikeAA7fJG80loBUBj22yvwDZve7tXxz5HW1Of3KxUTa+4cjDCHVsrYhJO8OEULGt3RwIHegDiozQPSCKJxW43S7WClq7zamWS5SB3LUMdU2qbHo4gEStADgQA4cAdHaEA6qWVhGbPv5q//AK2n+5qtaqmz7+av/wCtp/uarWvkeUfxdp3ugREXnAiIgp1x/rJj/VJ/fBTKhrj/AFkx/qk/vgplfcXb8PZd3jLKvUREXQoIs72z7Z7Zsdtdrkqm0s9xu1SaShp62vioKcuDC975aiTvY2NaOJ0JJLQASQs/oPddUlxsFfPS2Gmut7obzbrRNQ2a9wVlPKa1+7DJDVNAY7iHAtcGEFpB051WaojmHoRFjj/dEDG6LOBmWPPsdzxaClqZKO31Yrm1sdSXMpxC/cjJe6Rpj3S0aEjiQdVC4pnOb3z3R9jt+S2KbEqSTFK2qba4rwK2CZ4qqYNe9rWtaJWBzm8x0Dzo46lM0DfURFYFAZX/AEjHv1tB/wCJT6gMr/pGPfraD/xJ1T3T/ErU9KF3REX5+2EREFe2fxmLEbe0x3WIgP7y9O3qsfCO/nD931aKwqv4DA6mxKgjdBcKYtD/AIK6S8pUN793x3dP1fVorApnWQREUAiIgg6/w1sH2FX90as6rFf4a2D7Cr+6NWdevyd0K/e+WlnXqjsj8Hrp5rL7BXLj3yBbPNYvYC6sj8Hrp5rL7BXLj3yBbPNYvYC5r/6enu8U0aJBERcK4iIgIiIKNgfg+/z+u/1cqsKr2B+D7/P67/Vyqwr9Dr6UsaulLIYdlmR0W0XOHsfaKzB8z3ZLiyaWWOvpnCjFM5sQDCx7XbjDq5zSNXDQ8FXLFsRzmup8BxrK7lYZ8Qwuohqaee3Cbs25GnidFTCZjmhkQAcHO3XP3i3hpqvQKLLLCrztZ9gebR2HFsCuN1sb9n+O3OCtirIOWNyrIKeXlaenkjLRGzRwYHPa86hvADVTVv2WZtjGP5nZKCDEchtd2v8AUXWmpL82cRy01TJJLPBOGscA5r3N3XAOBAOrQdFt6JlgZ/sL2e3HZfs5o7BdK2GrqYp55mxUjnup6SOSVz2U8Jf3xjjDg1pdx0HMOZaAiKYjDmEZs+/mr/8Araf7mq1qqbPv5q//AK2n+5qta+R5R/F2ne6BERecCIiCnXH+smP9Un98FMqGuP8AWTH+qT++CmV9xdvw9l3eMsq9VVyvaZZMMuEdFco7w+eSITNNvsddXM3SSOL4IXtB1ae9J15jpoRrDnbvioYH8hkuhJGnanddeGnR2Nr0/f8AMtCRb86jE82oDtqq8fyHCJ5aPJsQrHVMEeTWWto6SqjnifFLC/lYmOIc3jvsDt0gajiF1ZDs6zXOcUs0F5bjVvutFlFuu7orU6bkG0lNPHI5m+5m8+U7r9DusbxA4aEnYkUYDD9pWwC5bQcgz+rbc6a3Q3y1WqC3TtDny09XRVEs7XyMLQNzedGODiSN7gOGv5t1hzm0bSaPaLn/ALwxUNrsFRan02Lx1tbO+SWop3iRsXIl7m/BnVrQS353DUjckTLAzwbecUJ/mMmH6cSuw/8A8y6LZtqxq7XGloaeHIhPUythjM+L3OGMOcdBvSPpw1g1PFziAOckBXtE5wUBlf8ASMe/W0H/AIlPqAyv+kY9+toP/ErdU90/xK1PShd0RF+fthERBXdn0HY2IW+Psa40m6H/AAN1fv1LfhHfHPT84+ohWJV7Z9DyGIW+MUtwotA/4C6Sb9Q34R3x3dPzj6iFYVNWskCIigEREEHX+Gtg+wq/ujVnVYr/AA1sH2FX90as69fk7oV+98tLOvVHZH4PXTzWX2CuXHvkC2eaxewF1ZH4PXTzWX2CuXHvkC2eaxewFzX/ANPT3eKaNEgiIuFcREQEREGf2WvpMWFXabpVQ0FQyrqZ4jUSCNs0Uk0kjXMJPfaB2h05iDqANNZPtssfjm3+tM61aKmkgrI9yohjnZz7srA4f8CuTtetXiyj9XZ1L6anlazmP7lE49eE/wClZpiZxQXbZY/HNv8AWmdadtlj8c2/1pnWp3tetXiyj9XZ1J2vWrxZR+rs6lbztYepPGPojJCC7bLH45t/rTOtO2yx+Obf60zrU72vWrxZR+rs6k7XrV4so/V2dSedrD1J4x9DJCC7bLH45t/rTOtfibMrBBGXvvdva0f/AFTCf0Aa8T9SsHa9avFlH6uzqX0gs1vpZRJDQ00Mg5nxwtaR/eAnnaw7OeMfQyQiMFoJ6S2VdRURPp311bNVtikbuvYxx0ZvDoJaASDxGuh0I0VjRF87b2s29pVa1azK4iIsQREQU7Jy2y5TSXqqcIra6jfRzVDviQP32uYXn+y098N48AdAdNQv2MtsZAIvVvIPT2VH1q2kBwII1B4EFcJx+1uJJttGSekwM6l7925TosrKmztKJnDrif8ASs0xKB7bLH45t/rTOtO2yx+Obf60zrU72vWrxZR+rs6k7XrV4so/V2dS6fO1h6k8Y+iMkILtssfjm3+tM607bLH45t/rTOtTva9avFlH6uzqTtetXiyj9XZ1J52sPUnjH0MkILtssfjm3+tM607bLH45t/rTOtV7YPZLdUbKbHJLQ000h5fV74Wkn4eTpIV+7XrV4so/V2dStPKthE4ZJ4x9DLCC7bLH45t/rTOtO2yx+Obf60zrU72vWrxZR+rs6k7XrV4so/V2dSr52sPUnjH0MkILtssfjm3+tM61H1FbTZXebRS2uoirhR1jauqmp3h7IWNa7QOcDoHOcWgN59NTzDVW3tetXiyj9XZ1LsgpoqWIRwRMhjHMyNoaB/cFnacrUTRMWdE4zGHPO/8ARMUxHO+iIi+bWEREFewCA02I0EZp7jSlof8ABXWTlKlvwjvju6fnH1aKwqu7PoBTYhb4xT3GkDQ/4G7P3qlvwjvjn/mPqIViUzrJAiIoBERBB1/hrYPsKv7o1Z1WK/w1sH2FX90as69fk7oV+98tLOvVHZH4PXTzWX2CuXHvkC2eaxewF1ZH4PXTzWX2CuXHvkC2eaxewFzX/wBPT3eKaNEgiIuFcREQEREBERAREQEREBERAREQEREBERAREQEREBERBn2wIabJbF3u7/P8P/2JFoKz7YFp3JbFppp8Pza6f0iT51oKtX0pRGgiIqpEREBERAREQV7Z/EIcQt7BS3GiAD/gLq/fqW/CO+Oen5x9RCsKruz6J0OIW9jqe40rgH/A3aTlKlvwjvju6fnH1aKxKZ1kgREUAiIgg6/w1sH2FX90as6rFf4a2D7Cr+6NWdevyd0K/e+WlnXq/E0LKiGSKRofG9pa5p5iDwIUA3Z5jrWhrbXEABoAHO4f81YkXoWljZWuE2lMT3xEqRMxorvc+x7xZF6TutO59j3iyL0ndasSLLY7t2dPCE5p3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3q73Pse8WRek7rTufY94si9J3WrEibHduzp4QZp3se2C4LY6nZRZJJrdG+UmoBJc7XhUSD5/qV/7n2PeLIvSd1qu7AxyezWGDUE0t0utK4DodFcamMj+4tI/uWiJN0u8zjNnTwgzTvV3ufY94si9J3Wnc+x7xZF6TutWJE2O7dnTwgzTvV3ufY94si9J3Wnc+x7xZF6TutWJE2O7dnTwgzTvV3ufY94si9J3Wnc+x7xZF6TutWJE2O7dnTwgzTvV3ufY94si9J3Wnc+x7xZF6TutWJE2O7dnTwgzTvZ9gWzywtxK3iSyVlK/dcTFdZS+pb37vjkHj9X1aKf7n2PeLIvSd1ps6hMGCWFrqa4UTnUcb3U12l5SriLmhxZM7peNdD9YViTZLvP/wA6eEGad6u9z7HvFkXpO607n2PeLIvSd1qxImx3bs6eEGad6u9z7HvFkXpO607n2PeLIvSd1qxImx3bs6eEGad6HtuIWez1gqqOgjgqGtLBICSQDpqOJ+oKYRFvRZ0WUZbOmIj2cyJmZ1ERFogREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQZ5sm/9WXPPbC5u4bfkM9TH/wBOOrZHV74+rlJ5m/pjctDWeZg3tHzy3ZkNW2mugjst6LR/Ngy60lS7/oxvkljcehtQHHRsZK0NAREQEREBERAUTllVNRYteJ6eiqrjUR0kro6OhcGzzvDDoyNx4BzjoATwBOpUsq/lNG+8VNotj7dLWUEtU2pqqiOpELafkCJYi4DvpN6VkbdwcCN7eOneuCUs9tjs1oobfCZHRUkDIGGWQyPLWtDRvOPFx4cSeddiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiD41lHT3GknpKuCOppZ2OilgmYHskY4aOa5p4EEEgg86o9hrJ9m9fS43dp5Kiw1Eghst2qHl7oyT3lFUPPO4cGxSk6yABjyZQHTX5cl1tVJe7dUUFfTsqqOoYY5YZBq1zT0IOtF4W2/e7qn2E5VDs/x+tpcrq7bcYOzr1NIZHwUrXgyUUvDR9QACx0oPBp4gShxb7ht1wp7tb6WupJWz0tTE2aGVvM9jgC0j9IIQdCIiAiIg+c88VLBJNNIyGGNpe+SRwa1rQNSSTzADpUDjFvZVVtbkU9JRsr69rYIqmkndOJKKN7zT98eHESOeQ0aAyaau03j/L/uZHX9r8ctO+nDWyXamqqMzsnpHtkbyGrhyYLyO+B3juB3ejea4WNAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAVWyG/V0l3NltMkdNUxwMqamsmj5QRMeXtY1rdRq4ljidToAOY7w0tKov+8bIPMaH2qhdd3piZqmY0jH94jxTDItpnuRMO2t1ktbkVPSyXCVznvrqOhjpZ3uJ1LnPi3d869LtVomJYZesLxi12G35ZVOoLbTspafsikikeI2DRrS4jU6AAfoCuCLrz+yPhj6GKG7Dybyqk9Qh6k7Dybyqk9Qh6lMopz+yPhj6GKG7Dybyqk9Qh6k7Dybyqk9Qh6lMomf2R8MfQxVy32PJLdFIxuYVc5klfK59RSxSO1c4nQajg0a6Bo0AA4BdXYeTeVUnqEPUplEz+yPhj6GKIZe7zi74qi6XCO7Wx8rIZXdjCKaAvcGteC06OaCRvDQHTiDw0N6WdbQfBGu/TH+8atFXNeKYy014YTOMbtMPqTpiIiLhQIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICov+8bIPMaH2qhXpUX/eNkHmND7VQu27f593jC0aSl0RYBnmCWTaD7qq0W/IaJlztkeF1MzqKYkwzO7NhaOUbzPA3iQDqNQ087QtJnBVv6LxLXYe7aVmO099/yvFMavNpvc9BRS3unqBX2mja1vYctI9tZCyJhaWvaWs7529vF3MrNUYngVftV2uN2m1luq57dabMTcayYQSMcKN4kqIRvasfvAEFvEEgAquYekH55b49o0OFmGp99JbU+8NmDW8gIWTMiLSd7e3954Om7pprx6FZF5J2QZfcKDMNnN7y+WaS7T7Lp5CJz/KKxzKmGTdaHcXymNocRzniT0qv7HexbPtj2SXq0dreP0+Z0dfLPZbJVzz1LoDSmaLsyWSVwmka5re+3GkODxq5M49rIvFWC4pa7Fsn2P5pQ05gymozOnoZroJHmaSmlr5oHwFxP81yeg3PijTXTVe1VamcRXdoPgjXfpj/eNWirOtoPgjXfpj/eNWiqLx6Kjvn+KU9QiIvPQIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICov+8bIPMaH2qhXpUUjTaNf/MaH2qhdt2/z7vGFo0lLrjNmt7ru27GhpjdGwGlbXGFvLiEuDjGH6b24XAHd101AK7EWyqAvOz/ABfIrvTXW643aLndKYAQV1ZQRTTxAHUbr3NLm8fmKqjNhGO120jJ8tvtvteRPu/YRpqe422OU0DqeNzC5j373F2oPAN03RzrSkUYQOCusNsudZQVdZbqSrqqB5kpJ54GvfTOI0Lo3EasJHDUacFFW7ZpiFon5egxWyUU3ZIrOUp7dDG7lwCBLqGjvwHO77n748eKsiJgIePDrBDbaK3R2O2st9FUNq6WkbSRiKnma8vbJGzTRrw8lwcACCSedTCIgru0HwRrv0x/vGrRVnW0Ea4jXAcSTEP+8atFVbx6Kjvn+KU9QiIvPQIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICruQ4zUVle26WuoipbmIhBJy7C+KeMFxa1wBBBa5ziCObecNDrwsSLSiuqznNSnRSDa8x1OjbHp9pN/Cv5715l+TYv8Sb+FXhF0bVV6scE4qP715l+TYv8Sb+FPevMvybF/iTfwq8Im1VerHAxZ3aIM6uFAyeqt9nts7nPBppp5HuaA4gHVoI74AOHHmI146rs968y/JsX+JN/CpjBLebXjFPTGzmwlss7uwHVXZJZvTPdvcpqdd/Xf06N7ToVgTaqvVjgYqP715l+TYv8Sb+FPevMvybF/iTfwq8Im1VerHAxU2lxS7XSohN+nouwoZGTCjoWvPKva4OYXvcfihwB3QOJA1OmoNyRFhaWtVpqiZxERFkgREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQVzZ7bm2rFKambZ32ENmqHdgSVHZBZvTyO3t/p39d/To3tOhWNVzZ7RtoMUpoW2mayATVB7CqJzM9ms8h3i884drvgdAcB0KxoCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIqhtQ2s4rsZxpuQZhc3WmzmdlN2S2lmqAJHAloLYmOcAd08SNNdBrqQg7sBpHUOLU8LrZPZyJqg9h1NR2Q9uszzvF/SHa7wHQHAdCsKwv3Nnujtme1emdjeFXCY3Kjjqa6a2ywVJMURqSC8zSRtad4yNcGg6gP00706bogIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIsN2mZ7LktdV2ahlMdmp3ugqHxktdVSNJD26/Rg6gj+0Qde9+N3XS6V3y0yUc0dc7hoF32vYrZ6l9O65GsqGEh8dBC+p3SOcFzAWg/UTqow7d8bBI5C6n/APResdjjbExrGNDGNGga0aABf1fV08i3WI/qmZnvj6GMbmwd3fG/oLr6i9VTatmeFbWdnd+xK6U10NJdKV0G/wBgPJifzskH1tcGu/uVKRX8zXT28f8ARjG5TfcRYrZPc44TdXX2nrZcqu9STUy09G97Y6eMkRMafr1c86flAH4q9Jd3fG/oLr6i9Y+ieZrp7eP+jGNzYO7vjf0F19Reuil24YpPIGzVFZRa/wBupoZWsH6XBpA/vIWLoonkW6zH+XGPoYxuen6KuprlSx1VJURVVNINWTQvD2OHzgjgV915oxrIa3C7ka62aGOR29VUWukdSOnX5n6cz/qAOo4L0VZbxS5BaKO5UUnKUtVE2WNxGh0I10I6COYjoIIXzN+uFdyqiccaZ0nwlPth2oiLykCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiCGzO7SWDEL5c4RrNR0M9RGNNdXNjc4f8AMBebKKnFJRwQAl3JsDd5x1J0HOT0lem8itDMgx+52uR27HXUstM53zB7C0/evMlI6XkAyoZydVETFPGedkrTuvb/AHOBC+x5CmnydpEa4x/rxJ0fZFBZDm1sxeoigrmXF0kjN9vYdrqqtumunF0UbgD9ROqiu63j+mvJXz/+u3D8BfRTa2dM4TVHFR+9pm0mh2a2ikqqoRS1NbUClpYZ6plNG55BcS+V/esaA0kuOvQACSAqVTe6Opp7Jdqhlqp665W2qooJaW1XWKrhlbUyiNjo52gNJB3tWuDeIGpAOqlsrpG7VorZcMZnlpL3jta2sp/fq2VNNBNvMex0ThJG0lrmk6lmpboPnX7v2F5Vl+Huobmyw0Vx99KOrYy3ul5FsMM0cjg57mauedx+negcQPnK466raqqZs55sObCInHm378Uv2dsfvF2yxZXZ/eSqslFFcTHS1Qq21EMjnMZuO3Wd/vsLN0jnI4kcVD2zL8qu22DFaa82abGaSe1V0womXIVDJyHQbpka0NAezU8+um+dDzqQz7ZDVZ1fslndWw0lHc7FTW6CRurpYqiGokma8t00LQXM6dToebnXPHaMupMvs+XZebQ2ks9BU0skdiZVVM0rpnRaPEYjLiO84tGu785HNWry2OFUzhExu38+P6YbhrCKnN2tY+86CK+cxPHHrgOb/sF9KLajYq+sgpYo7yJZ5GxsMthr42ak6DVzoQ1o485IA6Su7y1nP+UcULatZ2D18ktivFC9xcykr3GIE8zJGMkI9Nzz/esmWw7DbW+kxOpuEjd330q3VMXAjWINbGw8eghm8PqcF5PLE0xdJx3xh3//AJivT1tFREXwQIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICy/aXsynuFVLe7HHylY/Tsqh3g0T6DQPYTwD9NAQSA4AcQRx1BF1Xe82l1tItLOef+R5Rkr4KepfS1DjR1bPj01UDFK39LXaFfTsmH6VnpBen7haaG7xCKuo6etiHMyoibI3/gQVFHZ5iriScZs5J4kmgi/hX09PLtnh/VZzj3mEPOvZMP0rPSCdkw/Ss9IL0T3O8U8mbN6hF/Cnc7xTyZs3qEX8Kt59sfUn9jCHnbsmH6VnpBOyYfpWekF6J7neKeTNm9Qi/hTud4p5M2b1CL+FPPtj6k/sYQ87dkw/Ss9IL5T3SjpRrLVQx//dIBqvR3c7xTyZs3qEX8K7bdi9ms8okoLRQ0Mg4b9NTMjP8AxACieXbLDms54wYQxfC9mtdl8zJrjBPbrGDq/lQYpqofkMHO1h6XnQ6fF595u8wwx08LIomNiiY0NYxg0a0DgAB0BftF85fL7aXyvNXzRGkAiIuAEREBERB//9k=",
-      "text/plain": [
-       "<IPython.core.display.Image object>"
-      ]
+      "text/plain": "<IPython.core.display.Image object>"
      },
      "metadata": {},
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "from IPython.display import Image, display\n",
-    "\n",
-    "display(Image(app.get_graph(xray=True).draw_mermaid_png()))"
-   ]
+   "source": "from IPython.display import Image, display\n\ndisplay(Image(app.get_graph(xray=True).draw_mermaid_png()))"
   },
   {
    "cell_type": "code",
@@ -483,32 +281,19 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "{'plan': [\"Identify the winner of the men's 2024 Australian Open.\", 'Research the hometown of the identified winner.']}\n",
-      "{'past_steps': [(\"Identify the winner of the men's 2024 Australian Open.\", \"The winner of the men's singles tennis title at the 2024 Australian Open was Jannik Sinner. He defeated Daniil Medvedev in the final with scores of 3-6, 3-6, 6-4, 6-4, 6-3 to win his first major singles title.\")]}\n",
-      "{'plan': ['Research the hometown of Jannik Sinner.']}\n",
-      "{'past_steps': [('Research the hometown of Jannik Sinner.', \"Jannik Sinner's hometown is Sexten, which is located in northern Italy.\")]}\n",
-      "{'response': \"The hometown of the men's 2024 Australian Open winner, Jannik Sinner, is Sexten, located in northern Italy.\"}\n"
-     ]
+     "text": "{'plan': [\"Identify the winner of the men's 2024 Australian Open.\", 'Research the hometown of the identified winner.']}\n{'past_steps': [(\"Identify the winner of the men's 2024 Australian Open.\", \"The winner of the men's singles tennis title at the 2024 Australian Open was Jannik Sinner. He defeated Daniil Medvedev in the final with scores of 3-6, 3-6, 6-4, 6-4, 6-3 to win his first major singles title.\")]}\n{'plan': ['Research the hometown of Jannik Sinner.']}\n{'past_steps': [('Research the hometown of Jannik Sinner.', \"Jannik Sinner's hometown is Sexten, which is located in northern Italy.\")]}\n{'response': \"The hometown of the men's 2024 Australian Open winner, Jannik Sinner, is Sexten, located in northern Italy.\"}\n"
     }
    ],
-   "source": [
-    "config = {\"recursion_limit\": 50}\n",
-    "inputs = {\"input\": \"what is the hometown of the mens 2024 Australia open winner?\"}\n",
-    "async for event in app.astream(inputs, config=config):\n",
-    "    for k, v in event.items():\n",
-    "        if k != \"__end__\":\n",
-    "            print(v)"
-   ]
+   "source": "config = {\"recursion_limit\": 50}\ninputs = {\"input\": \"what is the hometown of the mens 2024 Australia open winner?\"}\nasync for event in app.astream(inputs, config=config):\n    for k, v in event.items():\n        if k != \"__end__\":\n            print(v)"
   },
   {
    "cell_type": "markdown",
    "id": "8bf585a9-0f1e-4910-bd00-65e7bb05b6e6",
    "metadata": {},
    "source": [
-    "## Conclusion\n",
-    "\n",
-    "Congrats on making a plan-and-execute agent! One known limitations of the above design is that each task is still executed in sequence, meaning embarrassingly parallel operations all add to the total execution time. You could improve on this by having each task represented as a DAG (similar to LLMCompiler), rather than a regular list."
+    "## 마무리",
+    "",
+    "계획-실행 에이전트를 만든 것을 축하합니다! 위 설계의 알려진 한계는 각 작업이 여전히 순차적으로 실행되어, 병렬로 처리할 수 있는 작업들도 전체 실행 시간에 모두 더해진다는 점입니다. 각 작업을 일반 리스트가 아니라 DAG(LLMCompiler와 유사)로 표현하면 이를 개선할 수 있습니다."
    ]
   }
  ],

--- a/examples/plan-and-execute/plan-and-execute.ipynb
+++ b/examples/plan-and-execute/plan-and-execute.ipynb
@@ -1,33 +1,33 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "9138f92e",
-   "metadata": {},
-   "source": [
-    "This file has been moved to https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "9138f92e",
+      "metadata": {},
+      "source": [
+        "이 파일은 https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb 로 이동되었습니다"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.2"
+    }
   },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- translate plan-and-execute tutorial notebook into Korean, updating example stub accordingly

## Testing
- `make format`
- `make lint`
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7abfbf2b883269712a8a381dd49d0